### PR TITLE
fix: the custom service should be set if it exists, not depend on the existence of an standardservice

### DIFF
--- a/internal/provider/resource_internet_fw_rule.go
+++ b/internal/provider/resource_internet_fw_rule.go
@@ -2220,7 +2220,7 @@ func (r *internetFwRuleResource) Create(ctx context.Context, req resource.Create
 			}
 
 			// setting service custom
-			if !serviceInput.Standard.IsNull() {
+			if !serviceInput.Custom.IsNull() {
 				elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 				diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 				resp.Diagnostics.Append(diags...)
@@ -3145,7 +3145,7 @@ func (r *internetFwRuleResource) Create(ctx context.Context, req resource.Create
 					}
 
 					// setting service custom
-					if !serviceInput.Standard.IsNull() {
+					if !serviceInput.Custom.IsNull() {
 						elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 						diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 						resp.Diagnostics.Append(diags...)
@@ -4057,7 +4057,7 @@ func (r *internetFwRuleResource) Update(ctx context.Context, req resource.Update
 		}
 
 		// setting service custom
-		if !serviceInput.Standard.IsNull() {
+		if !serviceInput.Custom.IsNull() {
 			elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 			diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 			resp.Diagnostics.Append(diags...)
@@ -4983,7 +4983,7 @@ func (r *internetFwRuleResource) Update(ctx context.Context, req resource.Update
 				}
 
 				// setting service custom
-				if !serviceInput.Standard.IsNull() {
+				if !serviceInput.Custom.IsNull() {
 					elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 					diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 					resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_wan_fw_rule.go
+++ b/internal/provider/resource_wan_fw_rule.go
@@ -2977,7 +2977,7 @@ func (r *wanFwRuleResource) Create(ctx context.Context, req resource.CreateReque
 			}
 
 			// setting service custom
-			if !serviceInput.Standard.IsNull() {
+			if !serviceInput.Custom.IsNull() {
 				elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 				diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 				resp.Diagnostics.Append(diags...)
@@ -4180,7 +4180,7 @@ func (r *wanFwRuleResource) Create(ctx context.Context, req resource.CreateReque
 					}
 
 					// setting service custom
-					if !serviceInput.Standard.IsNull() {
+					if !serviceInput.Custom.IsNull() {
 						elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 						diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 						resp.Diagnostics.Append(diags...)
@@ -5368,7 +5368,7 @@ func (r *wanFwRuleResource) Update(ctx context.Context, req resource.UpdateReque
 		}
 
 		// setting service custom
-		if !serviceInput.Standard.IsNull() {
+		if !serviceInput.Custom.IsNull() {
 			elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 			diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 			resp.Diagnostics.Append(diags...)
@@ -6568,7 +6568,7 @@ func (r *wanFwRuleResource) Update(ctx context.Context, req resource.UpdateReque
 				}
 
 				// setting service custom
-				if !serviceInput.Standard.IsNull() {
+				if !serviceInput.Custom.IsNull() {
 					elementsServiceCustomInput := make([]types.Object, 0, len(serviceInput.Custom.Elements()))
 					diags = serviceInput.Custom.ElementsAs(ctx, &elementsServiceCustomInput, false)
 					resp.Diagnostics.Append(diags...)


### PR DESCRIPTION


There is an issue with the provider which cause Terraform to set rules allowing Any port if there is no standardservice configured. This is likely the change needed to allow it to work properly. 