### PR TITLE
ENG-177328 | fix(site-resource): align json file state codes with cato api

### DIFF
--- a/internal/provider/datasource_siteLocation.go
+++ b/internal/provider/datasource_siteLocation.go
@@ -226,29 +226,20 @@ func (d *siteLocationDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	filteredLocations := make([]SiteLocationJsonObj, 0)
 	for _, location := range allLocations {
-		tflog.Debug(ctx, "filteredLocations.location - "+fmt.Sprintf("%v", location))
 
 		matches := true
 		for _, filter := range filterList {
 			field := filter.Field.ValueString()
 			search := filter.Search.ValueString()
 			operation := filter.Operation.ValueString()
-			tflog.Debug(ctx, "location.field - "+fmt.Sprintf("%v", field))
 
 			var value string
 			switch field {
 			case "city":
-				tflog.Info(ctx, "city present - "+fmt.Sprintf("%v", location.City))
 				value = location.City
 			case "state_name":
-				if location.StateName == "" {
-					tflog.Debug(ctx, "state_name is not present on location - "+fmt.Sprintf("%v", location))
-					matches = false
-				}
-				tflog.Debug(ctx, "state_name present - "+fmt.Sprintf("%v", location.StateName))
 				value = location.StateName
 			case "country_name":
-				tflog.Debug(ctx, "country_name present - "+fmt.Sprintf("%v", location.CountryName))
 				value = location.CountryName
 			default:
 				continue
@@ -256,27 +247,23 @@ func (d *siteLocationDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 			if matches {
 				if operation == "exact" && !(value == search) {
-					tflog.Debug(ctx, "field '"+field+"' exact not matched - value '"+value+"' and search '"+search+"' "+fmt.Sprintf("%v", !(value == search)))
 					matches = false
 				} else if operation == "startsWith" && !(strings.HasPrefix(value, search)) {
-					tflog.Debug(ctx, "field '"+field+"' startsWith not matched - value '"+value+"' and search '"+search+"' "+fmt.Sprintf("%v", !(strings.HasPrefix(value, search))))
 					matches = false
 				} else if operation == "endsWith" && !(strings.HasSuffix(value, search)) {
-					tflog.Debug(ctx, "field '"+field+"' endsWith not matched - value '"+value+"' and search '"+search+"' "+fmt.Sprintf("%v", !(strings.HasSuffix(value, search))))
 					matches = false
 				} else if operation == "contains" && !(strings.Contains(value, search)) {
-					tflog.Debug(ctx, "field '"+field+"' contains not matched - value '"+value+"' and search '"+search+"' "+fmt.Sprintf("%v", !(strings.Contains(value, search))))
 					matches = false
 				}
 			}
 		}
 
-		tflog.Debug(ctx, "field match - "+fmt.Sprintf("%v", matches)+"' "+fmt.Sprintf("%v", location)+"'")
 		if matches {
+			tflog.Debug(ctx, "field match "+fmt.Sprintf("%v", location))
 			filteredLocations = append(filteredLocations, location)
 		}
 	}
-	tflog.Debug(ctx, "field match filteredLocations - "+fmt.Sprintf("%v", filteredLocations))
+
 	setLocations(ctx, resp, state.Filters, filteredLocations)
 }
 


### PR DESCRIPTION
Removes the state code of the entries in the site locations json file for those cities that don't belong to any of the following countries:
  - Australia
  - Brazil
  - China
  - India
  - Mexico
  - United States

For the same list of countries, some state codes and state names were updated with the right values.

This change prevents the `siteLocation` data source to send unknown state codes to the api while creating a site. It also allows the provider's site location data source to find cities & states in a more accurate way.


----------

Changes were tested using the tf module `terraform-cato-vsocket-aws` and the following variables as input:
```terraform
variable "region" {
  description = "AWS Region"
  type        = string
  default     = "eu-west-2"
}

variable "site_location" {
  description = "Site location which is used by the Cato Socket to connect to the closest Cato PoP. If not specified, the location will be derived from the Azure region dynamicaly."
  type = object({
    city         = string
    country_code = string
    state_code   = string
    timezone     = string
  })
  default = {
    city         = null
    country_code = null
    state_code   = null ## Optional - for countries with states
    timezone     = null
  }
}
```

Generated plan
<img width="1116" height="618" alt="Screenshot 2026-04-10 at 15 27 29" src="https://github.com/user-attachments/assets/16c976dd-6878-40a0-b722-023025857961" />






The following list of state codes returned by the API were not found in our `type_site_location_data.json` file, which means they have a different state code or name ( changes in this PR address this issue as well) :
```
- BR-DF
- BR-MA
- BR-RO
- CN-AH
- CN-BJ
- CN-CQ
- CN-FJ
- CN-GD
- CN-GS
- CN-GX
- CN-GZ
- CN-HA
- CN-HB
- CN-HE
- CN-HI
- CN-HL
- CN-HN
- CN-JL
- CN-JS
- CN-JX
- CN-LN
- CN-NM
- CN-NX
- CN-QH
- CN-SC
- CN-SD
- CN-SH
- CN-SN
- CN-SX
- CN-TJ
- CN-XJ
- CN-XZ
- CN-YN
- CN-ZJ
- IN-AN
- IN-CT
- IN-DD     # Unable to fix. The entry in main file is mixed with IN-DN
- IN-DN     # Unable to fix. The entry in main file is mixed with IN-DD
- IN-JH
- IN-OR
- IN-PY
- IN-TG
- IN-UT
- MX-DIF
- MX-QUE
- US-AS
- US-GU
- US-MP
- US-PR
- US-UM     # Unable to fix. The entry does not exist at all in main file
- US-VI
````