### PR TITLE
ENG-177328: makes site location datasource idempotent

### DIFF
--- a/internal/provider/datasource_siteLocation.go
+++ b/internal/provider/datasource_siteLocation.go
@@ -255,7 +255,7 @@ func (d *siteLocationDataSource) Read(
 	}
 
 	if locations := filterSiteLocations(ctx, filters); len(locations) > 0 {
-		setSiteLocations(ctx, resp, state.Filters, locations[:1])
+		setSiteLocations(ctx, resp, state.Filters, locations)
 		return
 	}
 
@@ -320,7 +320,7 @@ func filterSiteLocations(
 
 	siteLocations := make([]SLDCatalogEntry, 0, len(filteredSiteLocations))
 	for _, location := range filteredSiteLocations {
-		siteLocations = append(siteLocations, location)
+		siteLocations = insertSLDCatalogEntry(siteLocations, location)
 	}
 
 	return siteLocations
@@ -433,4 +433,45 @@ func setSiteLocations(
 	if diags := resp.State.Set(ctx, &state); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 	}
+}
+
+func insertSLDCatalogEntry(entries []SLDCatalogEntry, newEntry SLDCatalogEntry) []SLDCatalogEntry {
+	insertAt := len(entries)
+
+	compareSLDField := func(a, b string) int {
+		left := strings.TrimSpace(strings.ToLower(a))
+		right := strings.TrimSpace(strings.ToLower(b))
+
+		switch {
+		case left < right:
+			return -1
+		case left > right:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	isLess := func(a, b SLDCatalogEntry) bool {
+		if cmp := compareSLDField(a.City, b.City); cmp != 0 {
+			return cmp < 0
+		}
+		if cmp := compareSLDField(a.StateName, b.StateName); cmp != 0 {
+			return cmp < 0
+		}
+		return compareSLDField(a.CountryName, b.CountryName) < 0
+	}
+
+	for i, entry := range entries {
+		if isLess(newEntry, entry) {
+			insertAt = i
+			break
+		}
+	}
+
+	entries = append(entries, SLDCatalogEntry{})
+	copy(entries[insertAt+1:], entries[insertAt:])
+	entries[insertAt] = newEntry
+
+	return entries
 }

--- a/internal/provider/datasource_siteLocation_test.go
+++ b/internal/provider/datasource_siteLocation_test.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"sort"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -48,6 +48,14 @@ func TestFilterSiteLocations(t *testing.T) {
 			expectedSiteLocations: []SLDCatalogEntry{
 				{
 					City:        "Los Angeles",
+					CountryName: "United States",
+					CountryCode: "US",
+					StateName:   "California",
+					StateCode:   "US-CA",
+					Timezone:    []string{"America/Los_Angeles"},
+				},
+				{
+					City:        "Los Angeles",
 					CountryName: "Philippines",
 					CountryCode: "PH",
 					StateName:   "Caraga",
@@ -61,14 +69,6 @@ func TestFilterSiteLocations(t *testing.T) {
 					StateName:   "Madrid",
 					StateCode:   "",
 					Timezone:    []string{"Europe/Madrid"},
-				},
-				{
-					City:        "Los Angeles",
-					CountryName: "United States",
-					CountryCode: "US",
-					StateName:   "California",
-					StateCode:   "US-CA",
-					Timezone:    []string{"America/Los_Angeles"},
 				},
 			},
 		},
@@ -233,19 +233,6 @@ func TestFilterSiteLocations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results := filterSiteLocations(ctx, tt.filters)
-			sort.SliceStable(results, func(i, j int) bool {
-				a, b := results[i], results[j]
-
-				if a.CountryName != b.CountryName {
-					return a.CountryName < b.CountryName
-				}
-
-				if a.City != b.City {
-					return a.City < b.City
-				}
-
-				return true
-			})
 
 			if len(results) != len(tt.expectedSiteLocations) {
 				t.Errorf("expected %d results, got %d", len(tt.expectedSiteLocations), len(results))
@@ -284,4 +271,319 @@ func TestFilterSiteLocations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInsertSLDCatalogEntry(t *testing.T) {
+	t.Run("inserting a new entry into an empty list", func(t *testing.T) {
+		newEntry := SLDCatalogEntry{
+			City:        "Austin",
+			StateName:   "Texas",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{newEntry}
+
+		got := insertSLDCatalogEntry(nil, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a city name lexicographically lower than existing entries", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "Chicago",
+				StateName:   "Illinois",
+				CountryName: "United States",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "Boston",
+			StateName:   "Massachusetts",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{newEntry, entries[0]}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a city name lexicographically greater than existing entries", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "Boston",
+				StateName:   "Texas",
+				CountryName: "United States",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "Chicago",
+			StateName:   "Alabama",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{entries[0], newEntry}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a city name lexicographically lower than a few entries but greater than others", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "Atlanta",
+				StateName:   "Georgia",
+				CountryName: "United States",
+			},
+			{
+				City:        "Chicago",
+				StateName:   "Illinois",
+				CountryName: "United States",
+			},
+			{
+				City:        "Denver",
+				StateName:   "Colorado",
+				CountryName: "United States",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "Boston",
+			StateName:   "Massachusetts",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{entries[0], newEntry, entries[1], entries[2]}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a state name lexicographically lower than existing entries", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "CityA",
+				StateName:   "Illinois",
+				CountryName: "United States",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "CityA",
+			StateName:   "Georgia",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{newEntry, entries[0]}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a state name lexicographically greater than existing entries", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "CityA",
+				StateName:   "Georgia",
+				CountryName: "United States",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "CityA",
+			StateName:   "Illinois",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{entries[0], newEntry}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a state name lexicographically lower than some entries but greater than others", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "CityA",
+				StateName:   "Georgia",
+				CountryName: "United States",
+			},
+			{
+				City:        "CityA",
+				StateName:   "Illinois",
+				CountryName: "United States",
+			},
+			{
+				City:        "CityA",
+				StateName:   "Texas",
+				CountryName: "United States",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "CityA",
+			StateName:   "Massachusetts",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{entries[0], entries[1], newEntry, entries[2]}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a country name lexicographically lower than existing entries", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "CityA",
+				StateName:   "StateA",
+				CountryName: "United States",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "CityA",
+			StateName:   "StateA",
+			CountryName: "Argentina",
+		}
+		expected := []SLDCatalogEntry{newEntry, entries[0]}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a country name lexicographically greater than existing entries", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "CityA",
+				StateName:   "StateA",
+				CountryName: "Argentina",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "CityA",
+			StateName:   "StateA",
+			CountryName: "United States",
+		}
+		expected := []SLDCatalogEntry{entries[0], newEntry}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert a new entry with a country name lexicographically lower than some entries but greater than others", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "CityA",
+				StateName:   "StateA",
+				CountryName: "Argentina",
+			},
+			{
+				City:        "CityA",
+				StateName:   "StateA",
+				CountryName: "United States",
+			},
+			{
+				City:        "CityA",
+				StateName:   "StateA",
+				CountryName: "Zimbabwe",
+			},
+		}
+		newEntry := SLDCatalogEntry{
+			City:        "CityA",
+			StateName:   "StateA",
+			CountryName: "Brazil",
+		}
+		expected := []SLDCatalogEntry{entries[0], newEntry, entries[1], entries[2]}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+	})
+
+	t.Run("insert new entries in different positions", func(t *testing.T) {
+		entries := []SLDCatalogEntry{
+			{
+				City:        "CityA",
+				StateName:   "StateB",
+				CountryName: "CountryC",
+			},
+			{
+				City:        "CityA",
+				StateName:   "StateC",
+				CountryName: "CountryC",
+			},
+			{
+				City:        "CityB",
+				StateName:   "StateB",
+				CountryName: "CountryC",
+			},
+			{
+				City:        "CityC",
+				StateName:   "StateB",
+				CountryName: "CountryD",
+			},
+			{
+				City:        "CityC",
+				StateName:   "StateC",
+				CountryName: "CountryE",
+			},
+		}
+
+		newEntry := SLDCatalogEntry{
+			City:        "CityB",
+			StateName:   "StateA",
+			CountryName: "CountryC",
+		}
+		expected := []SLDCatalogEntry{
+			entries[0],
+			entries[1],
+			newEntry,
+			entries[2],
+			entries[3],
+			entries[4],
+		}
+
+		got := insertSLDCatalogEntry(entries, newEntry)
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got, expected)
+		}
+		newEntry2 := SLDCatalogEntry{
+			City:        "CityC",
+			StateName:   "StateB",
+			CountryName: "CountryB",
+		}
+		expected2 := []SLDCatalogEntry{
+			entries[0],
+			entries[1],
+			newEntry,
+			entries[2],
+			newEntry2,
+			entries[3],
+			entries[4],
+		}
+
+		got2 := insertSLDCatalogEntry(got, newEntry2)
+
+		if !reflect.DeepEqual(got2, expected2) {
+			t.Fatalf("unexpected entries: got %#v want %#v", got2, expected2)
+		}
+	})
 }


### PR DESCRIPTION
Due to the nature of the site location catalog structure, its entries are randomly sorted at loading time. Changes in this PR make sure that the returned values of the datasource are consistent when a filter is called.