### PR TITLE
fix ifw app ref handling and refresh state

### DIFF
--- a/internal/acctests/if_rule/if_rule_test.go
+++ b/internal/acctests/if_rule/if_rule_test.go
@@ -5,6 +5,7 @@ package if_rule
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"testing"
 	"text/template"
 
@@ -129,6 +130,58 @@ func TestAccInternetFw_Timeframe(t *testing.T) {
 				Config: cfg.getTfConfigTimeframe(0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.PrintAttributes(res),
+				),
+			},
+		},
+	})
+}
+
+func TestAccInternetFw_InvalidDestinationApplicationRef(t *testing.T) {
+	acc.SkipByEnv(t)
+	mockSrv := accmock.NewMockServer(t, "TestAccInternetFw_InvalidDestinationApplicationRef")
+	defer mockSrv.Close()
+	mockSrv.Run()
+	cfg := newInternetFwCfg(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 acc.CheckCMAVars(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg.getTfConfigInvalidDestinationApplicationRef(0),
+				ExpectError: regexp.MustCompile("Invalid object reference"),
+			},
+		},
+	})
+}
+
+func TestAccInternetFw_ServiceEmptyKnownAfterRefresh(t *testing.T) {
+	acc.SkipByEnv(t)
+	mockSrv := accmock.NewMockServer(t, "TestAccInternetFw_ServiceEmptyKnownAfterRefresh")
+	defer mockSrv.Close()
+	mockSrv.Run()
+	cfg := newInternetFwCfg(t)
+	res := "cato_if_rule.service_empty_refresh"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 acc.CheckCMAVars(t),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg.getTfConfigServiceEmptyKnownAfterRefresh(0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acc.PrintAttributes(res),
+					resource.TestCheckNoResourceAttr(res, "rule.service.%"),
+					resource.TestCheckNoResourceAttr(res, "rule.service.standard.#"),
+					resource.TestCheckNoResourceAttr(res, "rule.service.custom.#"),
+				),
+			},
+			{
+				Config: cfg.getTfConfigServiceEmptyKnownAfterRefresh(0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(res, "rule.service.%"),
+					resource.TestCheckNoResourceAttr(res, "rule.service.standard.#"),
+					resource.TestCheckNoResourceAttr(res, "rule.service.custom.#"),
 				),
 			},
 		},
@@ -807,6 +860,39 @@ var internetFwIDNameTFs = []string{
 }
 
 // ------------------------------------------------------------------
+// Invalid destination application ref cato_if_rule configuration
+// ------------------------------------------------------------------
+func (p internetFwCfg) getTfConfigInvalidDestinationApplicationRef(index int) string {
+	data := map[string]any{
+		"Name": p.resName,
+	}
+	return p.prepareTfCfg(data, internetFwInvalidDestinationApplicationRefTFs[index])
+}
+
+var internetFwInvalidDestinationApplicationRefTFs = []string{
+	`resource "cato_if_rule" "invalid_destination_app_ref" {
+		at = {
+			position = "LAST_IN_POLICY"
+		}
+		rule = {
+			name    = "{{ .Name }} invalid-app-ref"
+			enabled = true
+			action  = "ALLOW"
+			tracking = {
+				event = {
+					enabled = true
+				}
+			}
+			destination = {
+				application = [ {} ]
+			}
+			source = {}
+		}
+	}
+	`,
+}
+
+// ------------------------------------------------------------------
 // Timeframe cato_if_rule configurations
 // - test combination of name and ID attributes in the rule configuration
 // ------------------------------------------------------------------
@@ -939,6 +1025,39 @@ var internetFwUserIDTFs = []string{
 					}
 				}
 			]
+		}
+	}
+	`,
+}
+
+// ------------------------------------------------------------------
+// Empty service known-value cato_if_rule configuration
+// ------------------------------------------------------------------
+func (p internetFwCfg) getTfConfigServiceEmptyKnownAfterRefresh(index int) string {
+	data := map[string]any{
+		"Name": p.resName,
+	}
+	return p.prepareTfCfg(data, internetFwServiceEmptyKnownAfterRefreshTFs[index])
+}
+
+var internetFwServiceEmptyKnownAfterRefreshTFs = []string{
+	`resource "cato_if_rule" "service_empty_refresh" {
+		at = {
+			position = "LAST_IN_POLICY"
+		}
+		rule = {
+			name    = "{{ .Name }} service-empty"
+			enabled = true
+			action  = "ALLOW"
+			tracking = {
+				event = {
+					enabled = true
+				}
+			}
+			destination = {
+				domain = [ "service-empty.example.com" ]
+			}
+			source = {}
 		}
 	}
 	`,

--- a/internal/provider/hydrate_ifw_rule_api.go
+++ b/internal/provider/hydrate_ifw_rule_api.go
@@ -19,6 +19,13 @@ const (
 	defaultConnectionOriginAny = "ANY"
 )
 
+func appendObjectRefTransformError(diags []diag.Diagnostic, fieldPath string, err error) []diag.Diagnostic {
+	return append(diags, diag.NewErrorDiagnostic(
+		"Invalid object reference",
+		fmt.Sprintf("Unable to convert %s into API reference: %v", fieldPath, err),
+	))
+}
+
 // hydrateIfwAPITypes create sub-types for both create and update calls to populate both entries
 type hydrateIfwAPITypes struct {
 	create cato_models.InternetFirewallAddRuleInput
@@ -523,7 +530,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationApplicationInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.destination.application", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleDestinationInput.Application = append(ruleDestinationInput.Application, &cato_models.ApplicationRefInput{
@@ -547,7 +555,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationCustomAppInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.destination.custom_app", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleDestinationInput.CustomApp = append(ruleDestinationInput.CustomApp, &cato_models.CustomApplicationRefInput{
@@ -614,7 +623,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationAppCategoryInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.destination.app_category", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleDestinationInput.AppCategory = append(ruleDestinationInput.AppCategory, &cato_models.ApplicationCategoryRefInput{
@@ -638,7 +648,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationCustomCategoryInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.destination.custom_category", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleDestinationInput.CustomCategory = append(ruleDestinationInput.CustomCategory, &cato_models.CustomCategoryRefInput{
@@ -665,7 +676,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationSanctionedAppsCategoryInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.destination.sanctioned_apps_category", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleDestinationInput.SanctionedAppsCategory = append(
@@ -1479,7 +1491,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationApplicationInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.destination.application", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Destination.Application = append(exceptionAddInput.Destination.Application, &cato_models.ApplicationRefInput{
@@ -1503,7 +1516,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationCustomAppInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.destination.custom_app", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Destination.CustomApp = append(exceptionAddInput.Destination.CustomApp, &cato_models.CustomApplicationRefInput{
@@ -1570,7 +1584,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationAppCategoryInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.destination.app_category", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Destination.AppCategory = append(
@@ -1597,7 +1612,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationCustomCategoryInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.destination.custom_category", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Destination.CustomCategory = append(
@@ -1627,7 +1643,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationSanctionedAppsCategoryInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.destination.sanctioned_apps_category", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Destination.SanctionedAppsCategory = append(

--- a/internal/provider/hydrate_ifw_rule_state.go
+++ b/internal/provider/hydrate_ifw_rule_state.go
@@ -22,11 +22,6 @@ func hydrateIfwRuleState(
 ) PolicyPolicyInternetFirewallPolicyRulesRule {
 	ruleInput := PolicyPolicyInternetFirewallPolicyRulesRule{}
 	diags := make(diag.Diagnostics, 0)
-	diagstmp := state.Rule.As(ctx, &ruleInput, basetypes.ObjectAsOptions{})
-	diags = append(diags, diagstmp...)
-	if diags.HasError() {
-		return ruleInput
-	}
 	ruleInput.Name = types.StringValue(currentRule.Name)
 	ruleInput.Enabled = types.BoolValue(currentRule.Enabled)
 	if currentRule.Description == "" {
@@ -143,20 +138,18 @@ func hydrateIfwRuleState(
 	// /// /// /// /// end Rule -> Destination // /// /// /// /// /
 
 	// /// /// /// /// start Rule -> Service // /// /// /// /// /
-	if len(currentRule.Service.Custom) > 0 || len(currentRule.Service.Standard) > 0 {
-		// Initialize Service object with null values
+	if len(currentRule.Service.Custom) == 0 && len(currentRule.Service.Standard) == 0 {
+		ruleInput.Service = types.ObjectNull(IfwServiceAttrTypes)
+	} else {
 		curRuleServiceObj, diagstmp := types.ObjectValue(
 			IfwServiceAttrTypes,
 			map[string]attr.Value{
-				"standard": types.SetNull(NameIDObjectType),
-				"custom":   types.ListNull(CustomServiceObjectType),
+				"standard": parseNameIDList(ctx, currentRule.Service.Standard, "rule.service.standard"),
+				"custom":   types.ListValueMust(CustomServiceObjectType, []attr.Value{}),
 			},
 		)
 		diags = append(diags, diagstmp...)
 		curRuleServiceObjAttrs := curRuleServiceObj.Attributes()
-
-		// Rule -> Service -> Standard
-		curRuleServiceObjAttrs["standard"] = parseNameIDList(ctx, currentRule.Service.Standard, "rule.service.standard")
 
 		// Rule -> Service -> Custom
 		if len(currentRule.Service.Custom) > 0 {
@@ -168,7 +161,6 @@ func hydrateIfwRuleState(
 			curRuleServiceObjAttrs["custom"], diagstmp = types.ListValueFrom(ctx, CustomServiceObjectType, curRuleCustomServices)
 			diags = append(diags, diagstmp...)
 		}
-
 		curRuleServiceObj, diagstmp = types.ObjectValue(curRuleServiceObj.AttributeTypes(ctx), curRuleServiceObjAttrs)
 		diags = append(diags, diagstmp...)
 		ruleInput.Service = curRuleServiceObj
@@ -395,9 +387,14 @@ func hydrateIfwRuleState(
 	}
 
 	configuredActivePeriod := PolicyPolicyInternetFirewallPolicyRulesRuleActivePeriod{}
-	if !ruleInput.ActivePeriod.IsNull() && !ruleInput.ActivePeriod.IsUnknown() {
-		diagstmp = ruleInput.ActivePeriod.As(ctx, &configuredActivePeriod, basetypes.ObjectAsOptions{})
+	if !state.Rule.IsNull() && !state.Rule.IsUnknown() {
+		stateRuleInput := PolicyPolicyInternetFirewallPolicyRulesRule{}
+		diagstmp = state.Rule.As(ctx, &stateRuleInput, basetypes.ObjectAsOptions{})
 		diags = append(diags, diagstmp...)
+		if !stateRuleInput.ActivePeriod.IsNull() && !stateRuleInput.ActivePeriod.IsUnknown() {
+			diagstmp = stateRuleInput.ActivePeriod.As(ctx, &configuredActivePeriod, basetypes.ObjectAsOptions{})
+			diags = append(diags, diagstmp...)
+		}
 	}
 
 	// If API returned nil but we have configured values in state, preserve them

--- a/internal/provider/resource_internet_fw_rule_test.go
+++ b/internal/provider/resource_internet_fw_rule_test.go
@@ -180,6 +180,39 @@ func TestUseStateExceptionDeviceAttributesReturnsNullWithoutMatch(t *testing.T) 
 	}
 }
 
+func TestHydrateIfwRuleAPIFailsOnInvalidDestinationApplicationRef(t *testing.T) {
+	ctx := context.Background()
+
+	model := newMinimalInternetFwRuleModel("")
+	ruleAttrs := model.Rule.Attributes()
+	destinationAttrs := ruleAttrs["destination"].(types.Object).Attributes()
+	destinationAttrs["application"] = types.SetValueMust(NameIDObjectType, []attr.Value{
+		types.ObjectValueMust(NameIDAttrTypes, map[string]attr.Value{
+			"id":   types.StringNull(),
+			"name": types.StringNull(),
+		}),
+	})
+	ruleAttrs["destination"] = types.ObjectValueMust(IfwDestAttrTypes, destinationAttrs)
+	model.Rule = types.ObjectValueMust(InternetFirewallRuleRuleAttrTypes, ruleAttrs)
+
+	_, diags := hydrateIfwRuleAPI(ctx, model)
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics for invalid destination application object reference")
+	}
+}
+
+func TestHydrateIfwRuleStateKeepsServiceNullWhenAPIReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	state := newMinimalInternetFwRuleModel("rule-123")
+	currentRule := minimalAPIRule("test-ifw-rule", 10)
+	hydrated := hydrateIfwRuleState(ctx, state, &currentRule)
+
+	if !hydrated.Service.IsNull() {
+		t.Fatalf("expected hydrated service to be null when API returns empty service, got %+v", hydrated.Service)
+	}
+}
+
 func TestInternetFwRuleDelete(t *testing.T) {
 	ctx := context.Background()
 	mockClient := mocks.NewInternetFirewallPolicyClient(t)
@@ -245,7 +278,7 @@ func TestInternetFwRuleCreateSuccess(t *testing.T) {
 		Once()
 	mockClient.EXPECT().
 		PolicyInternetFirewall(mock.Anything, mock.Anything, "account-123").
-		Return(internetFirewallPolicyResponseWithRule(minimalAPIRule("rule-123", "test-ifw-rule", 10)), nil).
+		Return(internetFirewallPolicyResponseWithRule(minimalAPIRule("test-ifw-rule", 10)), nil).
 		Once()
 
 	r := &internetFwRuleResource{
@@ -298,7 +331,7 @@ func TestInternetFwRuleReadSuccess(t *testing.T) {
 
 	mockClient.EXPECT().
 		PolicyInternetFirewall(mock.Anything, mock.Anything, "account-123").
-		Return(internetFirewallPolicyResponseWithRule(minimalAPIRule("rule-123", "updated-name", 11)), nil).
+		Return(internetFirewallPolicyResponseWithRule(minimalAPIRule("updated-name", 11)), nil).
 		Once()
 
 	r := &internetFwRuleResource{
@@ -363,7 +396,7 @@ func TestInternetFwRuleUpdateSuccess(t *testing.T) {
 		Once()
 	mockClient.EXPECT().
 		PolicyInternetFirewall(mock.Anything, mock.Anything, "account-123").
-		Return(internetFirewallPolicyResponseWithRule(minimalAPIRule("rule-123", "test-ifw-rule", 12)), nil).
+		Return(internetFirewallPolicyResponseWithRule(minimalAPIRule("test-ifw-rule", 12)), nil).
 		Once()
 
 	r := &internetFwRuleResource{
@@ -675,9 +708,9 @@ func internetFirewallPolicyResponseWithRule(rule cato_go_sdk.Policy_Policy_Inter
 	}
 }
 
-func minimalAPIRule(ruleID, name string, index int64) cato_go_sdk.Policy_Policy_InternetFirewall_Policy_Rules_Rule {
+func minimalAPIRule(name string, index int64) cato_go_sdk.Policy_Policy_InternetFirewall_Policy_Rules_Rule {
 	return cato_go_sdk.Policy_Policy_InternetFirewall_Policy_Rules_Rule{
-		ID:               ruleID,
+		ID:               "rule-123",
 		Name:             name,
 		Index:            index,
 		Enabled:          true,


### PR DESCRIPTION
Fail fast on invalid IFW destination object refs and preserve null service state when API returns no service values to avoid inconsistent apply results. Add unit and acceptance coverage for invalid destination refs and empty-service refresh behavior.