### PR TITLE
Harden IFW object-ref validation and service state compatibility.

### DIFF
--- a/internal/acctests/app_connector/app_connector_test.go
+++ b/internal/acctests/app_connector/app_connector_test.go
@@ -112,8 +112,8 @@ func TestAccAppConnector(t *testing.T) {
 					resource.TestCheckResourceAttr(res, "preferred_pop_location.automatic", "false"),
 					resource.TestCheckResourceAttr(res, "preferred_pop_location.preferred_only", "false"),
 					resource.TestCheckResourceAttr(res, "preferred_pop_location.primary.%", "2"),
-					resource.TestCheckResourceAttr(res, "preferred_pop_location.primary.id", cfg.locations[3].ID),
-					resource.TestCheckResourceAttr(res, "preferred_pop_location.primary.name", cfg.locations[3].Name),
+					resource.TestCheckResourceAttr(res, "preferred_pop_location.primary.id", cfg.locations[1].ID),
+					resource.TestCheckResourceAttr(res, "preferred_pop_location.primary.name", cfg.locations[1].Name),
 					resource.TestCheckResourceAttr(res, "preferred_pop_location.secondary.%", "2"),
 					resource.TestCheckResourceAttr(res, "preferred_pop_location.secondary.id", cfg.locations[0].ID),
 					resource.TestCheckResourceAttr(res, "preferred_pop_location.secondary.name", cfg.locations[0].Name),
@@ -208,8 +208,8 @@ var appConnectorTFs = []string{`
 		preferred_pop_location = {
 			automatic      = false
 			preferred_only = false
-			primary        = { id = "{{(index .Location 3).ID}}" }
-			secondary      = { id = "{{(index .Location 0).ID}}" }
+			primary        = { name = "{{(index .Location 1).Name}}" }
+			secondary      = { name = "{{(index .Location 0).Name}}" }
 		}
 		type = "VIRTUAL"
 	}`,

--- a/internal/provider/hydrate_ifw_rule_api.go
+++ b/internal/provider/hydrate_ifw_rule_api.go
@@ -96,7 +96,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceHostInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.host", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.Host = append(ruleSourceInput.Host, &cato_models.HostRefInput{
@@ -120,7 +121,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceSiteInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.site", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.Site = append(ruleSourceInput.Site, &cato_models.SiteRefInput{
@@ -163,7 +165,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceGlobalIPRangeInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.global_ip_range", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.GlobalIPRange = append(ruleSourceInput.GlobalIPRange, &cato_models.GlobalIPRangeRefInput{
@@ -187,7 +190,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceNetworkInterfaceInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.network_interface", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.NetworkInterface = append(ruleSourceInput.NetworkInterface, &cato_models.NetworkInterfaceRefInput{
@@ -211,7 +215,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceSiteNetworkSubnetInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.site_network_subnet", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.SiteNetworkSubnet = append(ruleSourceInput.SiteNetworkSubnet, &cato_models.SiteNetworkSubnetRefInput{
@@ -235,7 +240,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceFloatingSubnetInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.floating_subnet", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.FloatingSubnet = append(ruleSourceInput.FloatingSubnet, &cato_models.FloatingSubnetRefInput{
@@ -259,7 +265,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceUserInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.user", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.User = append(ruleSourceInput.User, &cato_models.UserRefInput{
@@ -283,7 +290,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceUsersGroupInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.users_group", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.UsersGroup = append(ruleSourceInput.UsersGroup, &cato_models.UsersGroupRefInput{
@@ -307,7 +315,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceGroupInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.group", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.Group = append(ruleSourceInput.Group, &cato_models.GroupRefInput{
@@ -331,7 +340,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceSystemGroupInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.source.system_group", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleSourceInput.SystemGroup = append(ruleSourceInput.SystemGroup, &cato_models.SystemGroupRefInput{
@@ -359,7 +369,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 				ObjectRefOutput, err := utils.TransformObjectRefInput(itemCountryInput)
 				if err != nil {
-					tflog.Error(ctx, err.Error())
+					diags = appendObjectRefTransformError(diags, "rule.country", err)
+					return hydrateAPIReturn, diags
 				}
 
 				rootAddRule.Country = append(rootAddRule.Country, &cato_models.CountryRefInput{
@@ -383,7 +394,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 				ObjectRefOutput, err := utils.TransformObjectRefInput(itemDeviceInput)
 				if err != nil {
-					tflog.Error(ctx, err.Error())
+					diags = appendObjectRefTransformError(diags, "rule.device", err)
+					return hydrateAPIReturn, diags
 				}
 
 				rootAddRule.Device = append(rootAddRule.Device, &cato_models.DeviceProfileRefInput{
@@ -599,7 +611,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationGlobalIPRangeInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.destination.global_ip_range", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleDestinationInput.GlobalIPRange = append(ruleDestinationInput.GlobalIPRange, &cato_models.GlobalIPRangeRefInput{
@@ -704,7 +717,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationCountryInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.destination.country", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleDestinationInput.Country = append(ruleDestinationInput.Country, &cato_models.CountryRefInput{
@@ -740,7 +754,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 					ObjectRefOutput, err := utils.TransformObjectRefInput(itemServiceStandardInput)
 					if err != nil {
-						tflog.Error(ctx, err.Error())
+						diags = appendObjectRefTransformError(diags, "rule.service.standard", err)
+						return hydrateAPIReturn, diags
 					}
 
 					ruleServiceInput.Standard = append(ruleServiceInput.Standard, &cato_models.ServiceRefInput{
@@ -869,7 +884,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 						ObjectRefOutput, err := utils.TransformObjectRefInput(itemAlertSubscriptionGroupInput)
 						if err != nil {
-							tflog.Error(ctx, err.Error())
+							diags = appendObjectRefTransformError(diags, "rule.tracking.alert.subscription_group", err)
+							return hydrateAPIReturn, diags
 						}
 
 						rootAddRule.Tracking.Alert.SubscriptionGroup = append(
@@ -896,7 +912,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 						ObjectRefOutput, err := utils.TransformObjectRefInput(itemAlertWebHookInput)
 						if err != nil {
-							tflog.Error(ctx, err.Error())
+							diags = appendObjectRefTransformError(diags, "rule.tracking.alert.webhook", err)
+							return hydrateAPIReturn, diags
 						}
 
 						rootAddRule.Tracking.Alert.Webhook = append(rootAddRule.Tracking.Alert.Webhook, &cato_models.SubscriptionWebhookRefInput{
@@ -921,7 +938,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 						ObjectRefOutput, err := utils.TransformObjectRefInput(itemAlertMailingListInput)
 						if err != nil {
-							tflog.Error(ctx, err.Error())
+							diags = appendObjectRefTransformError(diags, "rule.tracking.alert.mailing_list", err)
+							return hydrateAPIReturn, diags
 						}
 
 						rootAddRule.Tracking.Alert.MailingList = append(rootAddRule.Tracking.Alert.MailingList, &cato_models.SubscriptionMailingListRefInput{
@@ -1054,7 +1072,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceHostInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.host", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.Host = append(exceptionAddInput.Source.Host, &cato_models.HostRefInput{
@@ -1078,7 +1097,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceSiteInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.site", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.Site = append(exceptionAddInput.Source.Site, &cato_models.SiteRefInput{
@@ -1121,7 +1141,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceGlobalIPRangeInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.global_ip_range", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.GlobalIPRange = append(exceptionAddInput.Source.GlobalIPRange, &cato_models.GlobalIPRangeRefInput{
@@ -1145,7 +1166,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceNetworkInterfaceInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.network_interface", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.NetworkInterface = append(exceptionAddInput.Source.NetworkInterface, &cato_models.NetworkInterfaceRefInput{
@@ -1169,7 +1191,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceSiteNetworkSubnetInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.site_network_subnet", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.SiteNetworkSubnet = append(
@@ -1196,7 +1219,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceFloatingSubnetInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.floating_subnet", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.FloatingSubnet = append(exceptionAddInput.Source.FloatingSubnet, &cato_models.FloatingSubnetRefInput{
@@ -1220,7 +1244,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceUserInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.user", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.User = append(exceptionAddInput.Source.User, &cato_models.UserRefInput{
@@ -1244,7 +1269,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceUsersGroupInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.users_group", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.UsersGroup = append(exceptionAddInput.Source.UsersGroup, &cato_models.UsersGroupRefInput{
@@ -1268,7 +1294,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceGroupInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.group", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.Group = append(exceptionAddInput.Source.Group, &cato_models.GroupRefInput{
@@ -1292,7 +1319,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemSourceSystemGroupInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.source.system_group", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Source.SystemGroup = append(exceptionAddInput.Source.SystemGroup, &cato_models.SystemGroupRefInput{
@@ -1318,7 +1346,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 						ObjectRefOutput, err := utils.TransformObjectRefInput(itemCountryInput)
 						if err != nil {
-							tflog.Error(ctx, err.Error())
+							diags = appendObjectRefTransformError(diags, "rule.exceptions.country", err)
+							return hydrateAPIReturn, diags
 						}
 
 						exceptionAddInput.Country = append(exceptionAddInput.Country, &cato_models.CountryRefInput{
@@ -1343,7 +1372,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 						ObjectRefOutput, err := utils.TransformObjectRefInput(itemDeviceInput)
 						if err != nil {
-							tflog.Error(ctx, err.Error())
+							diags = appendObjectRefTransformError(diags, "rule.exceptions.device", err)
+							return hydrateAPIReturn, diags
 						}
 
 						exceptionAddInput.Device = append(exceptionAddInput.Device, &cato_models.DeviceProfileRefInput{
@@ -1560,7 +1590,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationGlobalIPRangeInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.destination.global_ip_range", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Destination.GlobalIPRange = append(exceptionAddInput.Destination.GlobalIPRange, &cato_models.GlobalIPRangeRefInput{
@@ -1671,7 +1702,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemDestinationCountryInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.destination.country", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Destination.Country = append(exceptionAddInput.Destination.Country, &cato_models.CountryRefInput{
@@ -1706,7 +1738,8 @@ func hydrateIfwRuleAPI(ctx context.Context, plan InternetFirewallRule) (hydrateI
 
 							ObjectRefOutput, err := utils.TransformObjectRefInput(itemServiceStandardInput)
 							if err != nil {
-								tflog.Error(ctx, err.Error())
+								diags = appendObjectRefTransformError(diags, "rule.exceptions.service.standard", err)
+								return hydrateAPIReturn, diags
 							}
 
 							exceptionAddInput.Service.Standard = append(exceptionAddInput.Service.Standard, &cato_models.ServiceRefInput{

--- a/internal/provider/hydrate_ifw_rule_state.go
+++ b/internal/provider/hydrate_ifw_rule_state.go
@@ -22,6 +22,11 @@ func hydrateIfwRuleState(
 ) PolicyPolicyInternetFirewallPolicyRulesRule {
 	ruleInput := PolicyPolicyInternetFirewallPolicyRulesRule{}
 	diags := make(diag.Diagnostics, 0)
+	stateRuleInput := PolicyPolicyInternetFirewallPolicyRulesRule{}
+	if !state.Rule.IsNull() && !state.Rule.IsUnknown() {
+		diagstmp := state.Rule.As(ctx, &stateRuleInput, basetypes.ObjectAsOptions{})
+		diags = append(diags, diagstmp...)
+	}
 	ruleInput.Name = types.StringValue(currentRule.Name)
 	ruleInput.Enabled = types.BoolValue(currentRule.Enabled)
 	if currentRule.Description == "" {
@@ -139,7 +144,13 @@ func hydrateIfwRuleState(
 
 	// /// /// /// /// start Rule -> Service // /// /// /// /// /
 	if len(currentRule.Service.Custom) == 0 && len(currentRule.Service.Standard) == 0 {
-		ruleInput.Service = types.ObjectNull(IfwServiceAttrTypes)
+		// Preserve prior known non-null service shape for backward compatibility.
+		// Some existing states carry an object with null nested fields instead of null.
+		if !stateRuleInput.Service.IsUnknown() && !stateRuleInput.Service.IsNull() {
+			ruleInput.Service = stateRuleInput.Service
+		} else {
+			ruleInput.Service = types.ObjectNull(IfwServiceAttrTypes)
+		}
 	} else {
 		curRuleServiceObj, diagstmp := types.ObjectValue(
 			IfwServiceAttrTypes,
@@ -387,14 +398,9 @@ func hydrateIfwRuleState(
 	}
 
 	configuredActivePeriod := PolicyPolicyInternetFirewallPolicyRulesRuleActivePeriod{}
-	if !state.Rule.IsNull() && !state.Rule.IsUnknown() {
-		stateRuleInput := PolicyPolicyInternetFirewallPolicyRulesRule{}
-		diagstmp = state.Rule.As(ctx, &stateRuleInput, basetypes.ObjectAsOptions{})
+	if !stateRuleInput.ActivePeriod.IsNull() && !stateRuleInput.ActivePeriod.IsUnknown() {
+		diagstmp = stateRuleInput.ActivePeriod.As(ctx, &configuredActivePeriod, basetypes.ObjectAsOptions{})
 		diags = append(diags, diagstmp...)
-		if !stateRuleInput.ActivePeriod.IsNull() && !stateRuleInput.ActivePeriod.IsUnknown() {
-			diagstmp = stateRuleInput.ActivePeriod.As(ctx, &configuredActivePeriod, basetypes.ObjectAsOptions{})
-			diags = append(diags, diagstmp...)
-		}
 	}
 
 	// If API returned nil but we have configured values in state, preserve them

--- a/internal/provider/resource_internet_fw_rule_test.go
+++ b/internal/provider/resource_internet_fw_rule_test.go
@@ -201,15 +201,56 @@ func TestHydrateIfwRuleAPIFailsOnInvalidDestinationApplicationRef(t *testing.T) 
 	}
 }
 
+func TestHydrateIfwRuleAPIFailsOnInvalidSourceHostRef(t *testing.T) {
+	ctx := context.Background()
+
+	model := newMinimalInternetFwRuleModel("")
+	ruleAttrs := model.Rule.Attributes()
+	sourceAttrs := ruleAttrs["source"].(types.Object).Attributes()
+	sourceAttrs["host"] = types.SetValueMust(NameIDObjectType, []attr.Value{
+		types.ObjectValueMust(NameIDAttrTypes, map[string]attr.Value{
+			"id":   types.StringNull(),
+			"name": types.StringNull(),
+		}),
+	})
+	ruleAttrs["source"] = types.ObjectValueMust(IfwSourceAttrTypes, sourceAttrs)
+	model.Rule = types.ObjectValueMust(InternetFirewallRuleRuleAttrTypes, ruleAttrs)
+
+	_, diags := hydrateIfwRuleAPI(ctx, model)
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics for invalid source host object reference")
+	}
+}
+
 func TestHydrateIfwRuleStateKeepsServiceNullWhenAPIReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	state := newMinimalInternetFwRuleModel("rule-123")
+	ruleAttrs := state.Rule.Attributes()
+	ruleAttrs["service"] = types.ObjectNull(IfwServiceAttrTypes)
+	state.Rule = types.ObjectValueMust(InternetFirewallRuleRuleAttrTypes, ruleAttrs)
+
+	currentRule := minimalAPIRule("test-ifw-rule", 10)
+	hydrated := hydrateIfwRuleState(ctx, state, &currentRule)
+
+	if !hydrated.Service.IsNull() {
+		t.Fatalf("expected hydrated service to be null when API returns empty service, got %+v", hydrated.Service)
+	}
+}
+
+func TestHydrateIfwRuleStatePreservesServiceObjectShapeWhenAPIReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 
 	state := newMinimalInternetFwRuleModel("rule-123")
 	currentRule := minimalAPIRule("test-ifw-rule", 10)
 	hydrated := hydrateIfwRuleState(ctx, state, &currentRule)
 
-	if !hydrated.Service.IsNull() {
-		t.Fatalf("expected hydrated service to be null when API returns empty service, got %+v", hydrated.Service)
+	if hydrated.Service.IsNull() || hydrated.Service.IsUnknown() {
+		t.Fatalf("expected hydrated service object shape to be preserved, got %+v", hydrated.Service)
+	}
+
+	if !hydrated.Service.Equal(emptyIfwServiceObject()) {
+		t.Fatalf("expected hydrated service to match prior object shape, got %+v", hydrated.Service)
 	}
 }
 


### PR DESCRIPTION
Fail fast with Terraform diagnostics for all IFW object-ref transform errors and add regression coverage for source host refs plus empty service shape preservation.