### PR TITLE
Fix IFW state drift for service, users_group, and bulk metadata.

### DIFF
--- a/internal/provider/hydrate_ifw_rule_state.go
+++ b/internal/provider/hydrate_ifw_rule_state.go
@@ -58,6 +58,16 @@ func hydrateIfwRuleState(
 		},
 	)
 	diags = append(diags, diagstmp...)
+	curRuleSourceObjAttrs := curRuleSourceObj.Attributes()
+	if !stateRuleInput.Source.IsNull() && !stateRuleInput.Source.IsUnknown() {
+		stateSourceAttrs := stateRuleInput.Source.Attributes()
+		curRuleSourceObjAttrs["users_group"] = preserveNullIDNameIDSet(
+			curRuleSourceObjAttrs["users_group"].(types.Set),
+			stateSourceAttrs["users_group"].(types.Set),
+		)
+	}
+	curRuleSourceObj, diagstmp = types.ObjectValue(curRuleSourceObj.AttributeTypes(ctx), curRuleSourceObjAttrs)
+	diags = append(diags, diagstmp...)
 	ruleInput.Source = curRuleSourceObj
 	// /// /// /// /// end rule.source // /// /// /// /// /
 
@@ -152,11 +162,18 @@ func hydrateIfwRuleState(
 			ruleInput.Service = types.ObjectNull(IfwServiceAttrTypes)
 		}
 	} else {
+		customServiceValue := types.ListNull(CustomServiceObjectType)
+		if !stateRuleInput.Service.IsNull() && !stateRuleInput.Service.IsUnknown() {
+			if stateServiceCustom, ok := stateRuleInput.Service.Attributes()["custom"]; ok && !stateServiceCustom.IsUnknown() {
+				customServiceValue = stateServiceCustom.(types.List)
+			}
+		}
+
 		curRuleServiceObj, diagstmp := types.ObjectValue(
 			IfwServiceAttrTypes,
 			map[string]attr.Value{
 				"standard": parseNameIDList(ctx, currentRule.Service.Standard, "rule.service.standard"),
-				"custom":   types.ListValueMust(CustomServiceObjectType, []attr.Value{}),
+				"custom":   customServiceValue,
 			},
 		)
 		diags = append(diags, diagstmp...)
@@ -471,6 +488,39 @@ func hydrateIfwRuleState(
 	// /// /// /// /// end Rule -> ActivePeriod // /// /// /// /// /
 
 	return ruleInput
+}
+
+func preserveNullIDNameIDSet(apiSet types.Set, stateSet types.Set) types.Set {
+	if apiSet.IsNull() || apiSet.IsUnknown() || stateSet.IsNull() || stateSet.IsUnknown() {
+		return apiSet
+	}
+
+	stateByName := make(map[string]types.Object)
+	for _, stateElem := range stateSet.Elements() {
+		stateObj := stateElem.(types.Object)
+		name := stateObj.Attributes()["name"].(types.String).ValueString()
+		stateByName[name] = stateObj
+	}
+
+	apiElems := apiSet.Elements()
+	updatedElems := make([]attr.Value, 0, len(apiElems))
+	for _, apiElem := range apiElems {
+		apiObj := apiElem.(types.Object)
+		apiAttrs := apiObj.Attributes()
+		apiName := apiAttrs["name"].(types.String).ValueString()
+
+		if stateObj, ok := stateByName[apiName]; ok {
+			stateID := stateObj.Attributes()["id"].(types.String)
+			if stateID.IsNull() || stateID.IsUnknown() {
+				apiAttrs["id"] = stateID
+				apiObj = types.ObjectValueMust(NameIDAttrTypes, apiAttrs)
+			}
+		}
+
+		updatedElems = append(updatedElems, apiObj)
+	}
+
+	return types.SetValueMust(NameIDObjectType, updatedElems)
 }
 
 func useStateExceptionDeviceAttributes(ctx context.Context, state InternetFirewallRule, exceptionName string) types.Object {

--- a/internal/provider/resource_internet_fw_rule_test.go
+++ b/internal/provider/resource_internet_fw_rule_test.go
@@ -254,6 +254,73 @@ func TestHydrateIfwRuleStatePreservesServiceObjectShapeWhenAPIReturnsEmpty(t *te
 	}
 }
 
+func TestHydrateIfwRuleStatePreservesNullCustomServiceWhenAPIReturnsEmptyCustom(t *testing.T) {
+	ctx := context.Background()
+
+	state := newMinimalInternetFwRuleModel("rule-123")
+	ruleAttrs := state.Rule.Attributes()
+	ruleAttrs["service"] = types.ObjectValueMust(IfwServiceAttrTypes, map[string]attr.Value{
+		"standard": types.SetValueMust(NameIDObjectType, []attr.Value{
+			types.ObjectValueMust(NameIDAttrTypes, map[string]attr.Value{
+				"id":   types.StringValue("svc-1"),
+				"name": types.StringValue("SMTP"),
+			}),
+		}),
+		"custom": types.ListNull(CustomServiceObjectType),
+	})
+	state.Rule = types.ObjectValueMust(InternetFirewallRuleRuleAttrTypes, ruleAttrs)
+
+	currentRule := minimalAPIRule("test-ifw-rule", 10)
+	currentRule.Service = cato_go_sdk.Policy_Policy_InternetFirewall_Policy_Rules_Rule_Service{
+		Standard: []*cato_go_sdk.Policy_Policy_InternetFirewall_Policy_Rules_Rule_Service_Standard{
+			{
+				ID:   "svc-1",
+				Name: "SMTP",
+			},
+		},
+		Custom: []*cato_go_sdk.Policy_Policy_InternetFirewall_Policy_Rules_Rule_Service_Custom{},
+	}
+
+	hydrated := hydrateIfwRuleState(ctx, state, &currentRule)
+	serviceAttrs := hydrated.Service.Attributes()
+	if !serviceAttrs["custom"].(types.List).IsNull() {
+		t.Fatalf("expected hydrated service.custom to remain null, got %+v", serviceAttrs["custom"])
+	}
+}
+
+func TestHydrateIfwRuleStatePreservesNullIDForSourceUsersGroup(t *testing.T) {
+	ctx := context.Background()
+
+	state := newMinimalInternetFwRuleModel("rule-123")
+	ruleAttrs := state.Rule.Attributes()
+	sourceAttrs := ruleAttrs["source"].(types.Object).Attributes()
+	sourceAttrs["users_group"] = types.SetValueMust(NameIDObjectType, []attr.Value{
+		types.ObjectValueMust(NameIDAttrTypes, map[string]attr.Value{
+			"id":   types.StringNull(),
+			"name": types.StringValue("Corp Users"),
+		}),
+	})
+	ruleAttrs["source"] = types.ObjectValueMust(IfwSourceAttrTypes, sourceAttrs)
+	state.Rule = types.ObjectValueMust(InternetFirewallRuleRuleAttrTypes, ruleAttrs)
+
+	currentRule := minimalAPIRule("test-ifw-rule", 10)
+	currentRule.Source.UsersGroup = []*cato_go_sdk.Policy_Policy_InternetFirewall_Policy_Rules_Rule_Source_UsersGroup{
+		{
+			ID:   "ug-123",
+			Name: "Corp Users",
+		},
+	}
+
+	hydrated := hydrateIfwRuleState(ctx, state, &currentRule)
+	hydratedUsersGroup := hydrated.Source.Attributes()["users_group"].(types.Set)
+	hydratedUserGroupObj := hydratedUsersGroup.Elements()[0].(types.Object)
+	hydratedUserGroupID := hydratedUserGroupObj.Attributes()["id"].(types.String)
+
+	if !hydratedUserGroupID.IsNull() {
+		t.Fatalf("expected hydrated users_group id to remain null for planned name-only ref, got %+v", hydratedUserGroupID)
+	}
+}
+
 func TestInternetFwRuleDelete(t *testing.T) {
 	ctx := context.Background()
 	mockClient := mocks.NewInternetFirewallPolicyClient(t)

--- a/internal/provider/resource_internet_fw_rules_index.go
+++ b/internal/provider/resource_internet_fw_rules_index.go
@@ -547,7 +547,7 @@ func (r *ifwRulesIndexResource) moveIfwRulesAndSections(
 				RuleName:       planSourceRuleIndex.RuleName.ValueString(),
 				SectionName:    planSourceRuleIndex.SectionName.ValueString(),
 				Description:    planSourceRuleIndex.Description.ValueString(),
-				Enabled:        planSourceRuleIndex.Enabled.ValueBool(),
+				Enabled:        planSourceRuleIndex.Enabled,
 			}
 			ruleListFromPlan = append(ruleListFromPlan, rulenDataTmp)
 		}
@@ -663,7 +663,7 @@ func (r *ifwRulesIndexResource) moveIfwRulesAndSections(
 					"section_name":     types.StringValue(ruleFromPlan.SectionName),
 					"rule_name":        types.StringValue(ruleFromPlan.RuleName),
 					"description":      types.StringValue(ruleFromPlan.Description),
-					"enabled":          types.BoolValue(ruleFromPlan.Enabled),
+					"enabled":          ruleFromPlan.Enabled,
 				},
 			)
 			diags = append(diags, ruleDiags...)

--- a/internal/provider/type_internet_fw_rules_index.go
+++ b/internal/provider/type_internet_fw_rules_index.go
@@ -20,7 +20,7 @@ type IfwRulesRuleDataIndex struct {
 	SectionName    string
 	RuleName       string
 	Description    string
-	Enabled        bool
+	Enabled        types.Bool
 }
 
 type IfwRulesSectionItemIndex struct {


### PR DESCRIPTION
Preserve null-vs-empty semantics for IFW service/custom and users_group name-only refs, and keep bulk IF rule_data.enabled as a Terraform bool value to avoid null-to-false drift.