### PR TITLE
fix bulk rule reorder computed-state handling

### DIFF
--- a/internal/provider/resource_bulk_rule_index_state_test.go
+++ b/internal/provider/resource_bulk_rule_index_state_test.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildIfwRuleIndexStateDataUsesAPIComputedFields(t *testing.T) {
+	t.Parallel()
+
+	rule := IfwRulesRuleDataIndex{
+		IndexInSection: 3,
+		SectionName:    "Section A",
+		RuleName:       "Rule A",
+		Description:    "plan description",
+		Enabled:        types.BoolUnknown(),
+	}
+
+	obj, diags := buildIfwRuleIndexStateData(
+		rule,
+		map[string]string{"Rule A": "rule-id-a"},
+		map[string]string{"Rule A": "api description"},
+		map[string]bool{"Rule A": true},
+	)
+	require.False(t, diags.HasError())
+
+	var got IfwRulesRuleItemIndex
+	asDiags := obj.As(context.Background(), &got, basetypes.ObjectAsOptions{})
+	require.False(t, asDiags.HasError())
+
+	require.Equal(t, "rule-id-a", got.ID.ValueString())
+	require.Equal(t, "api description", got.Description.ValueString())
+	require.True(t, got.Enabled.ValueBool())
+}
+
+func TestBuildWanRuleIndexStateDataUsesAPIComputedFields(t *testing.T) {
+	t.Parallel()
+
+	rule := WanRulesRuleDataIndex{
+		IndexInSection: 7,
+		SectionName:    "Section B",
+		RuleName:       "Rule B",
+		Description:    "plan description",
+		Enabled:        false,
+	}
+
+	obj, diags := buildWanRuleIndexStateData(
+		rule,
+		map[string]string{"Rule B": "rule-id-b"},
+		map[string]string{"Rule B": "api description"},
+		map[string]bool{"Rule B": true},
+	)
+	require.False(t, diags.HasError())
+
+	var got WanRulesRuleItemIndex
+	asDiags := obj.As(context.Background(), &got, basetypes.ObjectAsOptions{})
+	require.False(t, asDiags.HasError())
+
+	require.Equal(t, "rule-id-b", got.ID.ValueString())
+	require.Equal(t, "api description", got.Description.ValueString())
+	require.True(t, got.Enabled.ValueBool())
+}
+
+func TestBuildTLSRuleIndexStateDataUsesAPIComputedFields(t *testing.T) {
+	t.Parallel()
+
+	rule := TLSRulesRuleDataIndex{
+		IndexInSection: 11,
+		SectionName:    "Section C",
+		RuleName:       "Rule C",
+		Description:    "plan description",
+		Enabled:        false,
+	}
+
+	obj, diags := buildTLSRuleIndexStateData(
+		rule,
+		map[string]string{"Rule C": "rule-id-c"},
+		map[string]string{"Rule C": "api description"},
+		map[string]bool{"Rule C": true},
+	)
+	require.False(t, diags.HasError())
+
+	var got TLSRulesRuleItemIndex
+	asDiags := obj.As(context.Background(), &got, basetypes.ObjectAsOptions{})
+	require.False(t, asDiags.HasError())
+
+	require.Equal(t, "rule-id-c", got.ID.ValueString())
+	require.Equal(t, "api description", got.Description.ValueString())
+	require.True(t, got.Enabled.ValueBool())
+}

--- a/internal/provider/resource_internet_fw_rules_index.go
+++ b/internal/provider/resource_internet_fw_rules_index.go
@@ -576,10 +576,14 @@ func (r *ifwRulesIndexResource) moveIfwRulesAndSections(
 			return basetypes.MapValue{}, basetypes.MapValue{}, diags, err
 		}
 		ruleNameIDMap := make(map[string]string)
+		ruleNameDescriptionMap := make(map[string]string)
+		ruleNameEnabledMap := make(map[string]bool)
 
 		// create map of IFW rule names from the API to their IDs for easy lookup
 		for _, ruleNameIDDataItem := range ruleNameIDData.Policy.InternetFirewall.Policy.Rules {
 			ruleNameIDMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.ID
+			ruleNameDescriptionMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.Description
+			ruleNameEnabledMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.Enabled
 		}
 
 		tflog.Debug(ctx, "Processing rules in correct order", map[string]interface{}{
@@ -652,19 +656,13 @@ func (r *ifwRulesIndexResource) moveIfwRulesAndSections(
 			}
 		}
 
-		// Now create the rule objects map with proper IDs from the API
+		// Build final state using API values for computed fields so they are always known post-apply.
 		for _, ruleFromPlan := range ruleListFromPlan {
-			ruleID := ruleNameIDMap[ruleFromPlan.RuleName]
-			ruleIndexStateData, ruleDiags := types.ObjectValue(
-				IfwRuleIndexResourceAttrTypes,
-				map[string]attr.Value{
-					"id":               types.StringValue(ruleID),
-					"index_in_section": types.Int64Value(ruleFromPlan.IndexInSection),
-					"section_name":     types.StringValue(ruleFromPlan.SectionName),
-					"rule_name":        types.StringValue(ruleFromPlan.RuleName),
-					"description":      types.StringValue(ruleFromPlan.Description),
-					"enabled":          ruleFromPlan.Enabled,
-				},
+			ruleIndexStateData, ruleDiags := buildIfwRuleIndexStateData(
+				ruleFromPlan,
+				ruleNameIDMap,
+				ruleNameDescriptionMap,
+				ruleNameEnabledMap,
 			)
 			diags = append(diags, ruleDiags...)
 			ruleObjectMap[ruleFromPlan.RuleName] = ruleIndexStateData
@@ -699,4 +697,23 @@ func (r *ifwRulesIndexResource) moveIfwRulesAndSections(
 	diags = append(diags, ruleMapDiags...)
 
 	return sectionObjectsMap, ruleObjectsMap, diags, nil
+}
+
+func buildIfwRuleIndexStateData(
+	ruleFromPlan IfwRulesRuleDataIndex,
+	ruleNameIDMap map[string]string,
+	ruleNameDescriptionMap map[string]string,
+	ruleNameEnabledMap map[string]bool,
+) (basetypes.ObjectValue, diag.Diagnostics) {
+	return types.ObjectValue(
+		IfwRuleIndexResourceAttrTypes,
+		map[string]attr.Value{
+			"id":               types.StringValue(ruleNameIDMap[ruleFromPlan.RuleName]),
+			"index_in_section": types.Int64Value(ruleFromPlan.IndexInSection),
+			"section_name":     types.StringValue(ruleFromPlan.SectionName),
+			"rule_name":        types.StringValue(ruleFromPlan.RuleName),
+			"description":      types.StringValue(ruleNameDescriptionMap[ruleFromPlan.RuleName]),
+			"enabled":          types.BoolValue(ruleNameEnabledMap[ruleFromPlan.RuleName]),
+		},
+	)
 }

--- a/internal/provider/resource_tls_inspection_rules_index.go
+++ b/internal/provider/resource_tls_inspection_rules_index.go
@@ -444,10 +444,14 @@ func (r *tlsRulesIndexResource) moveTLSRulesAndSections(
 			return basetypes.MapValue{}, basetypes.MapValue{}, diags, err
 		}
 		ruleNameIDMap := make(map[string]string)
+		ruleNameDescriptionMap := make(map[string]string)
+		ruleNameEnabledMap := make(map[string]bool)
 
 		// create map of TLS rule names from the API to their IDs for easy lookup
 		for _, ruleNameIDDataItem := range ruleNameIDData.Policy.TLSInspect.Policy.Rules {
 			ruleNameIDMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.ID
+			ruleNameDescriptionMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.Description
+			ruleNameEnabledMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.Enabled
 		}
 
 		tflog.Warn(ctx, "Read.ruleNameIDMap.response", map[string]interface{}{
@@ -532,19 +536,13 @@ func (r *tlsRulesIndexResource) moveTLSRulesAndSections(
 			}
 		}
 
-		// Now create the rule objects map with proper IDs from the API
+		// Build final state using API values for computed fields so they are always known post-apply.
 		for _, ruleFromPlan := range ruleListFromPlan {
-			ruleID := ruleNameIDMap[ruleFromPlan.RuleName]
-			ruleIndexStateData, diagsSection := types.ObjectValue(
-				TLSRuleIndexResourceAttrTypes,
-				map[string]attr.Value{
-					"id":               types.StringValue(ruleID),
-					"index_in_section": types.Int64Value(ruleFromPlan.IndexInSection),
-					"section_name":     types.StringValue(ruleFromPlan.SectionName),
-					"rule_name":        types.StringValue(ruleFromPlan.RuleName),
-					"description":      types.StringValue(ruleFromPlan.Description),
-					"enabled":          types.BoolValue(ruleFromPlan.Enabled),
-				},
+			ruleIndexStateData, diagsSection := buildTLSRuleIndexStateData(
+				ruleFromPlan,
+				ruleNameIDMap,
+				ruleNameDescriptionMap,
+				ruleNameEnabledMap,
 			)
 			diags = append(diags, diagsSection...)
 			ruleObjectMap[ruleFromPlan.RuleName] = ruleIndexStateData
@@ -573,4 +571,23 @@ func (r *tlsRulesIndexResource) moveTLSRulesAndSections(
 	diags = append(diags, ruleMapDiags...)
 
 	return sectionObjectsMap, ruleObjectsMap, diags, nil
+}
+
+func buildTLSRuleIndexStateData(
+	ruleFromPlan TLSRulesRuleDataIndex,
+	ruleNameIDMap map[string]string,
+	ruleNameDescriptionMap map[string]string,
+	ruleNameEnabledMap map[string]bool,
+) (basetypes.ObjectValue, diag.Diagnostics) {
+	return types.ObjectValue(
+		TLSRuleIndexResourceAttrTypes,
+		map[string]attr.Value{
+			"id":               types.StringValue(ruleNameIDMap[ruleFromPlan.RuleName]),
+			"index_in_section": types.Int64Value(ruleFromPlan.IndexInSection),
+			"section_name":     types.StringValue(ruleFromPlan.SectionName),
+			"rule_name":        types.StringValue(ruleFromPlan.RuleName),
+			"description":      types.StringValue(ruleNameDescriptionMap[ruleFromPlan.RuleName]),
+			"enabled":          types.BoolValue(ruleNameEnabledMap[ruleFromPlan.RuleName]),
+		},
+	)
 }

--- a/internal/provider/resource_wan_fw_rules_index.go
+++ b/internal/provider/resource_wan_fw_rules_index.go
@@ -451,10 +451,14 @@ func (r *wanRulesIndexResource) moveWanRulesAndSections(
 			return basetypes.MapValue{}, basetypes.MapValue{}, diags, err
 		}
 		ruleNameIDMap := make(map[string]string)
+		ruleNameDescriptionMap := make(map[string]string)
+		ruleNameEnabledMap := make(map[string]bool)
 
 		// create map of IFW rule names from the API to their IDs for easy lookup
 		for _, ruleNameIDDataItem := range ruleNameIDData.Policy.WanFirewall.Policy.Rules {
 			ruleNameIDMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.ID
+			ruleNameDescriptionMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.Description
+			ruleNameEnabledMap[ruleNameIDDataItem.Rule.Name] = ruleNameIDDataItem.Rule.Enabled
 		}
 
 		tflog.Warn(ctx, "Read.ruleNameIDMap.response", map[string]interface{}{
@@ -539,19 +543,13 @@ func (r *wanRulesIndexResource) moveWanRulesAndSections(
 			}
 		}
 
-		// Now create the rule objects map with proper IDs from the API
+		// Build final state using API values for computed fields so they are always known post-apply.
 		for _, ruleFromPlan := range ruleListFromPlan {
-			ruleID := ruleNameIDMap[ruleFromPlan.RuleName]
-			ruleIndexStateData, diagsSection := types.ObjectValue(
-				WanRuleIndexResourceAttrTypes,
-				map[string]attr.Value{
-					"id":               types.StringValue(ruleID),
-					"index_in_section": types.Int64Value(ruleFromPlan.IndexInSection),
-					"section_name":     types.StringValue(ruleFromPlan.SectionName),
-					"rule_name":        types.StringValue(ruleFromPlan.RuleName),
-					"description":      types.StringValue(ruleFromPlan.Description),
-					"enabled":          types.BoolValue(ruleFromPlan.Enabled),
-				},
+			ruleIndexStateData, diagsSection := buildWanRuleIndexStateData(
+				ruleFromPlan,
+				ruleNameIDMap,
+				ruleNameDescriptionMap,
+				ruleNameEnabledMap,
 			)
 			diags = append(diags, diagsSection...)
 			ruleObjectMap[ruleFromPlan.RuleName] = ruleIndexStateData
@@ -580,4 +578,23 @@ func (r *wanRulesIndexResource) moveWanRulesAndSections(
 	diags = append(diags, ruleMapDiags...)
 
 	return sectionObjectsMap, ruleObjectsMap, diags, nil
+}
+
+func buildWanRuleIndexStateData(
+	ruleFromPlan WanRulesRuleDataIndex,
+	ruleNameIDMap map[string]string,
+	ruleNameDescriptionMap map[string]string,
+	ruleNameEnabledMap map[string]bool,
+) (basetypes.ObjectValue, diag.Diagnostics) {
+	return types.ObjectValue(
+		WanRuleIndexResourceAttrTypes,
+		map[string]attr.Value{
+			"id":               types.StringValue(ruleNameIDMap[ruleFromPlan.RuleName]),
+			"index_in_section": types.Int64Value(ruleFromPlan.IndexInSection),
+			"section_name":     types.StringValue(ruleFromPlan.SectionName),
+			"rule_name":        types.StringValue(ruleFromPlan.RuleName),
+			"description":      types.StringValue(ruleNameDescriptionMap[ruleFromPlan.RuleName]),
+			"enabled":          types.BoolValue(ruleNameEnabledMap[ruleFromPlan.RuleName]),
+		},
+	)
 }


### PR DESCRIPTION
Populate enabled and description from API snapshots for IF/WAN/TLS bulk move resources so post-apply state remains known and stable, and add unit tests for the state builders.