### PR TITLE
fix null optional string serialization

### DIFF
--- a/internal/provider/parse/parsers.go
+++ b/internal/provider/parse/parsers.go
@@ -180,7 +180,7 @@ func StringList[T fmt.Stringer](ctx context.Context, stringers []T, diags *diag.
 
 // KnownStringPointer returns a pointer to the known string value, nil for a null or unknown value.
 func KnownStringPointer(s types.String) *string {
-	if s.IsUnknown() {
+	if s.IsUnknown() || s.IsNull() {
 		return nil
 	}
 	return s.ValueStringPointer()

--- a/internal/provider/parse/parsers_test.go
+++ b/internal/provider/parse/parsers_test.go
@@ -1,0 +1,56 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestKnownStringPointer(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input    types.String
+		wantNil  bool
+		wantText string
+	}{
+		"null_returns_nil": {
+			input:   types.StringNull(),
+			wantNil: true,
+		},
+		"unknown_returns_nil": {
+			input:   types.StringUnknown(),
+			wantNil: true,
+		},
+		"known_value_returns_pointer": {
+			input:    types.StringValue("hello"),
+			wantText: "hello",
+		},
+		"known_empty_string_returns_pointer": {
+			input:    types.StringValue(""),
+			wantText: "",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := KnownStringPointer(tt.input)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil pointer, got %q", *got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("expected pointer to %q, got nil", tt.wantText)
+			}
+			if *got != tt.wantText {
+				t.Fatalf("expected %q, got %q", tt.wantText, *got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ensure parse.KnownStringPointer returns nil for null and unknown Terraform strings so optional API fields are omitted when unset.