### PR TITLE
Fix translated_subnet regression on socket site mutations.

### DIFF
--- a/internal/provider/resource_network_range.go
+++ b/internal/provider/resource_network_range.go
@@ -347,7 +347,7 @@ func (r *networkRangeResource) Create(ctx context.Context, req resource.CreateRe
 		Name:             plan.Name.ValueString(),
 		RangeType:        cato_models.SubnetType(plan.RangeType.ValueString()),
 		Subnet:           plan.Subnet.ValueString(),
-		TranslatedSubnet: parse.KnownStringPointer(plan.TranslatedSubnet),
+		TranslatedSubnet: stringPointerForOptionalInput(plan.TranslatedSubnet),
 		Vlan:             parse.KnownInt64Pointer(plan.Vlan),
 	}
 	// TODO: check if !isHA { // for HA scenario, local IP is not allowed to be modified
@@ -440,7 +440,7 @@ func (r *networkRangeResource) Update(ctx context.Context, req resource.UpdateRe
 		Name:             parse.KnownStringPointer(plan.Name),
 		RangeType:        (*cato_models.SubnetType)(parse.KnownStringPointer(plan.RangeType)),
 		Subnet:           parse.KnownStringPointer(plan.Subnet),
-		TranslatedSubnet: parse.KnownStringPointer(plan.TranslatedSubnet),
+		TranslatedSubnet: stringPointerForOptionalInput(plan.TranslatedSubnet),
 		Vlan:             parse.KnownInt64Pointer(plan.Vlan),
 	}
 

--- a/internal/provider/resource_site_socket.go
+++ b/internal/provider/resource_site_socket.go
@@ -913,7 +913,7 @@ func (r *socketSiteResource) prepareSocketSiteInput(ctx context.Context, plan *t
 		NativeNetworkRange: tfNativeRange.NativeNetworkRange.ValueString(),
 		SiteLocation:       r.prepareSiteLocation(ctx, plan.SiteLocation, diags),
 		SiteType:           cato_models.SiteType(plan.SiteType.ValueString()),
-		TranslatedSubnet:   parse.KnownStringPointer(tfNativeRange.TranslatedSubnet),
+		TranslatedSubnet:   stringPointerForOptionalInput(tfNativeRange.TranslatedSubnet),
 		Vlan:               (*scalars.Vlan)(parse.KnownInt64Pointer(tfNativeRange.Vlan)),
 	}
 	return input
@@ -929,7 +929,7 @@ func (r *socketSiteResource) prepareNetworkRangeInput(ctx context.Context, plan 
 	}
 	input := &cato_models.UpdateNetworkRangeInput{
 		Subnet:           parse.KnownStringPointer(tfNativeRange.NativeNetworkRange),
-		TranslatedSubnet: parse.KnownStringPointer(tfNativeRange.TranslatedSubnet),
+		TranslatedSubnet: stringPointerForOptionalInput(tfNativeRange.TranslatedSubnet),
 		MdnsReflector:    parse.KnownBoolPointer(tfNativeRange.MdnsReflector),
 		Vlan:             parse.KnownInt64Pointer(tfNativeRange.Vlan),
 		DhcpSettings:     dhcp.PrepareDHCPSettings(ctx, r.client, cato_models.SubnetTypeNative, tfNativeRange.DhcpSettings, diags),
@@ -996,7 +996,7 @@ func (r *socketSiteResource) prepareSocketInterfaceInput(ctx context.Context, pl
 		input.Lan = &cato_models.SocketInterfaceLanInput{
 			LocalIP:          tfNativeRange.LocalIP.ValueString(),
 			Subnet:           tfNativeRange.NativeNetworkRange.ValueString(),
-			TranslatedSubnet: tfNativeRange.TranslatedSubnet.ValueStringPointer(),
+			TranslatedSubnet: stringPointerForOptionalInput(tfNativeRange.TranslatedSubnet),
 		}
 	}
 

--- a/internal/provider/resource_site_socket_test.go
+++ b/internal/provider/resource_site_socket_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	cato_go_sdk "github.com/catonetworks/cato-go-sdk"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/catonetworks/terraform-provider-cato/internal/provider/mocks"
+	tf "github.com/catonetworks/terraform-provider-cato/internal/provider/tfmodel"
 	"github.com/catonetworks/terraform-provider-cato/internal/provider/validators"
 )
 
@@ -169,4 +171,85 @@ func TestStringPointerForOptionalInput(t *testing.T) {
 
 func stringPtr(value string) *string {
 	return &value
+}
+
+func TestSocketSitePrepareInputsTranslatedSubnet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		translatedSubnet types.String
+		wantNil          bool
+		wantValue        string
+	}{
+		"null_omitted": {
+			translatedSubnet: types.StringNull(),
+			wantNil:          true,
+		},
+		"empty_omitted": {
+			translatedSubnet: types.StringValue(""),
+			wantNil:          true,
+		},
+		"unknown_omitted": {
+			translatedSubnet: types.StringUnknown(),
+			wantNil:          true,
+		},
+		"value_set": {
+			translatedSubnet: types.StringValue("192.168.20.0/24"),
+			wantValue:        "192.168.20.0/24",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			plan := newSocketSitePlanWithTranslatedSubnet(ctx, t, tt.translatedSubnet)
+			r := &socketSiteResource{client: &catoClientData{}}
+			var diags diag.Diagnostics
+
+			addInput := r.prepareSocketSiteInput(ctx, plan, &diags)
+			if diags.HasError() {
+				t.Fatalf("prepareSocketSiteInput: %v", diags)
+			}
+			assertTranslatedSubnetPointer(t, addInput.TranslatedSubnet, tt.wantNil, tt.wantValue)
+
+			networkRangeInput := r.prepareNetworkRangeInput(ctx, plan, false, &diags)
+			if diags.HasError() {
+				t.Fatalf("prepareNetworkRangeInput: %v", diags)
+			}
+			assertTranslatedSubnetPointer(t, networkRangeInput.TranslatedSubnet, tt.wantNil, tt.wantValue)
+
+			socketIfaceInput, _ := r.prepareSocketInterfaceInput(ctx, plan, false, &diags)
+			if diags.HasError() {
+				t.Fatalf("prepareSocketInterfaceInput: %v", diags)
+			}
+			if socketIfaceInput.Lan == nil {
+				t.Fatal("expected LAN input")
+			}
+			assertTranslatedSubnetPointer(t, socketIfaceInput.Lan.TranslatedSubnet, tt.wantNil, tt.wantValue)
+		})
+	}
+}
+
+func newSocketSitePlanWithTranslatedSubnet(ctx context.Context, t *testing.T, translatedSubnet types.String) *tf.SocketSite {
+	t.Helper()
+
+	nativeRange, diags := types.ObjectValueFrom(ctx, tf.SiteNativeRangeResourceAttrTypes, tf.NativeRange{
+		NativeNetworkRange: types.StringValue("10.51.0.128/25"),
+		LocalIP:            types.StringValue("10.51.0.1"),
+		TranslatedSubnet:   translatedSubnet,
+		DhcpSettings:       types.ObjectNull(tf.SiteNativeRangeDhcpResourceAttrTypes),
+	})
+	if diags.HasError() {
+		t.Fatalf("build native range: %v", diags)
+	}
+
+	return &tf.SocketSite{
+		Name:           types.StringValue("aws-site-01"),
+		ConnectionType: types.StringValue("SOCKET_AWS1500"),
+		SiteType:       types.StringValue("DATACENTER"),
+		NativeRange:    nativeRange,
+		SiteLocation:   types.ObjectNull(tf.SiteLocationResourceAttrTypes),
+	}
 }


### PR DESCRIPTION
Omit empty or unset translated_subnet from add/update API payloads so accounts without Static Range Translation can create sites again.