### PR TITLE
Fix socket site update sending hydrated translated_subnet.

### DIFF
--- a/internal/provider/resource_site_socket.go
+++ b/internal/provider/resource_site_socket.go
@@ -65,6 +65,26 @@ func stringPointerForOptionalInput(value types.String) *string {
 	return value.ValueStringPointer()
 }
 
+// translatedSubnetForAPIInput omits translated_subnet from update payloads when the attribute is not
+// explicitly set in Terraform config, even if plan/state still carry an API-hydrated value.
+func translatedSubnetForAPIInput(configValue, planValue types.String) *string {
+	if configValue.IsNull() || configValue.IsUnknown() {
+		return nil
+	}
+	return stringPointerForOptionalInput(planValue)
+}
+
+func nativeRangeTranslatedSubnetFromAPI(translatedSubnet *string, nativeSubnet string) types.String {
+	if translatedSubnet == nil {
+		return types.StringNull()
+	}
+	value := *translatedSubnet
+	if value == "" || value == nativeSubnet {
+		return types.StringNull()
+	}
+	return types.StringValue(value)
+}
+
 type socketSiteResource struct {
 	client           *catoClientData
 	socketSiteClient SocketSiteClient
@@ -370,7 +390,7 @@ func (r *socketSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.Append(diags...)
 		return
 	}
-	r.updateNetworkRange(ctx, &plan, networkRange.GetNetworkRangeID(), false, &diags)
+	r.updateNetworkRange(ctx, &cfg, &plan, networkRange.GetNetworkRangeID(), false, &diags)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -384,7 +404,7 @@ func (r *socketSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 	// Update Socket Interface
-	r.updateSocketInterface(ctx, &plan, siteID, false, &diags)
+	r.updateSocketInterface(ctx, &cfg, &plan, siteID, false, &diags)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -490,7 +510,7 @@ func (r *socketSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	networkRangeID := planNativeRange.NativeNetworkRangeID.ValueString()
-	r.updateNetworkRange(ctx, &plan, networkRangeID, isHA, &resp.Diagnostics)
+	r.updateNetworkRange(ctx, &cfg, &plan, networkRangeID, isHA, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -506,7 +526,7 @@ func (r *socketSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Update Socket Interface
-	r.updateSocketInterface(ctx, &plan, siteID, isHA, &resp.Diagnostics)
+	r.updateSocketInterface(ctx, &cfg, &plan, siteID, isHA, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -857,7 +877,7 @@ func (r *socketSiteResource) parseNativeRange(ctx context.Context, cfg *tf.Socke
 		LocalIP:               localIP,
 		PrimaryManagementIP:   types.StringPointerValue(networkRange.PrimaryManagementIP),
 		SecondaryManagementIP: types.StringPointerValue(networkRange.SecondaryManagementIP),
-		TranslatedSubnet:      types.StringPointerValue(networkRange.TranslatedSubnet),
+		TranslatedSubnet:      nativeRangeTranslatedSubnetFromAPI(networkRange.TranslatedSubnet, networkRange.Subnet),
 		Gateway:               types.StringPointerValue(networkRange.Gateway),
 		RangeType:             types.StringValue(strings.ToUpper(string(networkRange.RangeType))),
 		DhcpSettings:          dhcpSettingsObj,
@@ -921,23 +941,33 @@ func (r *socketSiteResource) prepareSocketSiteInput(ctx context.Context, plan *t
 
 // prepareNetworkRangeInput constructs the API input for SiteUpdateNetworkRange() from the Terraform plan data.
 // It may add error(s) to the diagnostics if the input data is invalid.
-func (r *socketSiteResource) prepareNetworkRangeInput(ctx context.Context, plan *tf.SocketSite, isHA bool, diags *diag.Diagnostics,
+func (r *socketSiteResource) prepareNetworkRangeInput(ctx context.Context, cfg, plan *tf.SocketSite, isHA bool, diags *diag.Diagnostics,
 ) *cato_models.UpdateNetworkRangeInput {
-	var tfNativeRange tf.NativeRange
-	if utils.CheckErr(diags, plan.NativeRange.As(ctx, &tfNativeRange, basetypes.ObjectAsOptions{})) {
+	var (
+		cfgNativeRange  tf.NativeRange
+		planNativeRange tf.NativeRange
+	)
+	if utils.CheckErr(diags, plan.NativeRange.As(ctx, &planNativeRange, basetypes.ObjectAsOptions{})) {
 		return nil
 	}
+	configTranslatedSubnet := types.StringNull()
+	if cfg != nil && utils.HasValue(cfg.NativeRange) {
+		if utils.CheckErr(diags, cfg.NativeRange.As(ctx, &cfgNativeRange, basetypes.ObjectAsOptions{})) {
+			return nil
+		}
+		configTranslatedSubnet = cfgNativeRange.TranslatedSubnet
+	}
 	input := &cato_models.UpdateNetworkRangeInput{
-		Subnet:           parse.KnownStringPointer(tfNativeRange.NativeNetworkRange),
-		TranslatedSubnet: stringPointerForOptionalInput(tfNativeRange.TranslatedSubnet),
-		MdnsReflector:    parse.KnownBoolPointer(tfNativeRange.MdnsReflector),
-		Vlan:             parse.KnownInt64Pointer(tfNativeRange.Vlan),
-		DhcpSettings:     dhcp.PrepareDHCPSettings(ctx, r.client, cato_models.SubnetTypeNative, tfNativeRange.DhcpSettings, diags),
+		Subnet:           parse.KnownStringPointer(planNativeRange.NativeNetworkRange),
+		TranslatedSubnet: translatedSubnetForAPIInput(configTranslatedSubnet, planNativeRange.TranslatedSubnet),
+		MdnsReflector:    parse.KnownBoolPointer(planNativeRange.MdnsReflector),
+		Vlan:             parse.KnownInt64Pointer(planNativeRange.Vlan),
+		DhcpSettings:     dhcp.PrepareDHCPSettings(ctx, r.client, cato_models.SubnetTypeNative, planNativeRange.DhcpSettings, diags),
 		//    AzureFloatingIP *string `json:"azureFloatingIp,omitempty"` TODO: implement when AZURE HA support is added
 	}
 
 	if !isHA { // for HA scenario, local IP is not allowed to be modified
-		input.LocalIP = parse.KnownStringPointer(tfNativeRange.LocalIP)
+		input.LocalIP = parse.KnownStringPointer(planNativeRange.LocalIP)
 	}
 
 	return input
@@ -945,10 +975,11 @@ func (r *socketSiteResource) prepareNetworkRangeInput(ctx context.Context, plan 
 
 // prepareSocketInterfaceInput prepares inputs for SiteUpdateSocketInterface API,
 // on error updates diags
-func (r *socketSiteResource) prepareSocketInterfaceInput(ctx context.Context, plan *tf.SocketSite, isHA bool, diags *diag.Diagnostics,
+func (r *socketSiteResource) prepareSocketInterfaceInput(ctx context.Context, cfg, plan *tf.SocketSite, isHA bool, diags *diag.Diagnostics,
 ) (*cato_models.UpdateSocketInterfaceInput, cato_models.SocketInterfaceIDEnum) {
 	var (
-		tfNativeRange     tf.NativeRange
+		cfgNativeRange  tf.NativeRange
+		planNativeRange tf.NativeRange
 		lagLinksDestTypes = []cato_models.SocketInterfaceDestType{ // set lag input for these dest types
 			cato_models.SocketInterfaceDestTypeLanLagMaster,
 			cato_models.SocketInterfaceDestTypeLanLagMasterAndVrrp,
@@ -962,20 +993,27 @@ func (r *socketSiteResource) prepareSocketInterfaceInput(ctx context.Context, pl
 		}
 	)
 
-	if utils.CheckErr(diags, plan.NativeRange.As(ctx, &tfNativeRange, basetypes.ObjectAsOptions{})) {
+	if utils.CheckErr(diags, plan.NativeRange.As(ctx, &planNativeRange, basetypes.ObjectAsOptions{})) {
 		return nil, ""
 	}
+	configTranslatedSubnet := types.StringNull()
+	if cfg != nil && utils.HasValue(cfg.NativeRange) {
+		if utils.CheckErr(diags, cfg.NativeRange.As(ctx, &cfgNativeRange, basetypes.ObjectAsOptions{})) {
+			return nil, ""
+		}
+		configTranslatedSubnet = cfgNativeRange.TranslatedSubnet
+	}
 
-	interfaceDestType := cato_models.SocketInterfaceDestType(tfNativeRange.InterfaceDestType.ValueString())
+	interfaceDestType := cato_models.SocketInterfaceDestType(planNativeRange.InterfaceDestType.ValueString())
 
 	if interfaceDestType == "" {
 		interfaceDestType = cato_models.SocketInterfaceDestTypeLan // default to LAN if not specified
 	}
 
 	// Determine interface ifaceName with the following precedence: InterfaceName > InterfaceIndex > default based on connection type
-	ifaceName := parse.KnownStringPointer(tfNativeRange.InterfaceName)
+	ifaceName := parse.KnownStringPointer(planNativeRange.InterfaceName)
 	if ifaceName == nil {
-		ifaceName = parse.KnownStringPointer(tfNativeRange.InterfaceIndex)
+		ifaceName = parse.KnownStringPointer(planNativeRange.InterfaceIndex)
 	}
 	if ifaceName == nil {
 		ifaceName = ptr(string(tf.InterfaceByConnType[cato_models.SiteConnectionTypeEnum(plan.ConnectionType.ValueString())]))
@@ -987,21 +1025,21 @@ func (r *socketSiteResource) prepareSocketInterfaceInput(ctx context.Context, pl
 	}
 
 	// MinLinks for LAG
-	if utils.HasValue(tfNativeRange.LagMinLinks) && slices.Contains(lagLinksDestTypes, interfaceDestType) {
-		input.Lag = &cato_models.SocketInterfaceLagInput{MinLinks: tfNativeRange.LagMinLinks.ValueInt64()}
+	if utils.HasValue(planNativeRange.LagMinLinks) && slices.Contains(lagLinksDestTypes, interfaceDestType) {
+		input.Lag = &cato_models.SocketInterfaceLagInput{MinLinks: planNativeRange.LagMinLinks.ValueInt64()}
 	}
 
 	// LAN input
 	if slices.Contains(lanDestTypes, interfaceDestType) && !isHA {
 		input.Lan = &cato_models.SocketInterfaceLanInput{
-			LocalIP:          tfNativeRange.LocalIP.ValueString(),
-			Subnet:           tfNativeRange.NativeNetworkRange.ValueString(),
-			TranslatedSubnet: stringPointerForOptionalInput(tfNativeRange.TranslatedSubnet),
+			LocalIP:          planNativeRange.LocalIP.ValueString(),
+			Subnet:           planNativeRange.NativeNetworkRange.ValueString(),
+			TranslatedSubnet: translatedSubnetForAPIInput(configTranslatedSubnet, planNativeRange.TranslatedSubnet),
 		}
 	}
 
 	// get interface index if configured, otherwise use a default based on connection type
-	interfaceIndex := cato_models.SocketInterfaceIDEnum(tfNativeRange.InterfaceIndex.ValueString())
+	interfaceIndex := cato_models.SocketInterfaceIDEnum(planNativeRange.InterfaceIndex.ValueString())
 	if interfaceIndex == "" {
 		interfaceIndex = tf.InterfaceByConnType[cato_models.SiteConnectionTypeEnum(plan.ConnectionType.ValueString())]
 	}
@@ -1176,10 +1214,10 @@ func (r *socketSiteResource) assignInterfaceIndex(ctx context.Context, currentIn
 }
 
 // updateNativeRange updates the native network range details by calling SiteUpdateNetworkRange API.
-func (r *socketSiteResource) updateNetworkRange(ctx context.Context, plan *tf.SocketSite, networkRangeID string,
+func (r *socketSiteResource) updateNetworkRange(ctx context.Context, cfg, plan *tf.SocketSite, networkRangeID string,
 	isHA bool, diags *diag.Diagnostics,
 ) {
-	networkRangeInput := r.prepareNetworkRangeInput(ctx, plan, isHA, diags)
+	networkRangeInput := r.prepareNetworkRangeInput(ctx, cfg, plan, isHA, diags)
 	if diags.HasError() {
 		return
 	}
@@ -1192,14 +1230,14 @@ func (r *socketSiteResource) updateNetworkRange(ctx context.Context, plan *tf.So
 }
 
 // updateSocketInterface updates the socket interface details.
-func (r *socketSiteResource) updateSocketInterface(ctx context.Context, plan *tf.SocketSite, siteID string,
+func (r *socketSiteResource) updateSocketInterface(ctx context.Context, cfg, plan *tf.SocketSite, siteID string,
 	isHA bool, diags *diag.Diagnostics,
 ) {
 	if isHA && plan.ConnectionType.ValueString() == string(cato_models.SiteConnectionTypeEnumSocketGCP1500) {
 		return // update does not work on GCP HA
 	}
 
-	socketIfaceInput, interfaceID := r.prepareSocketInterfaceInput(ctx, plan, isHA, diags)
+	socketIfaceInput, interfaceID := r.prepareSocketInterfaceInput(ctx, cfg, plan, isHA, diags)
 	if diags.HasError() {
 		return
 	}

--- a/internal/provider/resource_site_socket.go
+++ b/internal/provider/resource_site_socket.go
@@ -978,8 +978,8 @@ func (r *socketSiteResource) prepareNetworkRangeInput(ctx context.Context, cfg, 
 func (r *socketSiteResource) prepareSocketInterfaceInput(ctx context.Context, cfg, plan *tf.SocketSite, isHA bool, diags *diag.Diagnostics,
 ) (*cato_models.UpdateSocketInterfaceInput, cato_models.SocketInterfaceIDEnum) {
 	var (
-		cfgNativeRange  tf.NativeRange
-		planNativeRange tf.NativeRange
+		cfgNativeRange    tf.NativeRange
+		planNativeRange   tf.NativeRange
 		lagLinksDestTypes = []cato_models.SocketInterfaceDestType{ // set lag input for these dest types
 			cato_models.SocketInterfaceDestTypeLanLagMaster,
 			cato_models.SocketInterfaceDestTypeLanLagMasterAndVrrp,

--- a/internal/provider/resource_site_socket.go
+++ b/internal/provider/resource_site_socket.go
@@ -74,17 +74,6 @@ func translatedSubnetForAPIInput(configValue, planValue types.String) *string {
 	return stringPointerForOptionalInput(planValue)
 }
 
-func nativeRangeTranslatedSubnetFromAPI(translatedSubnet *string, nativeSubnet string) types.String {
-	if translatedSubnet == nil {
-		return types.StringNull()
-	}
-	value := *translatedSubnet
-	if value == "" || value == nativeSubnet {
-		return types.StringNull()
-	}
-	return types.StringValue(value)
-}
-
 type socketSiteResource struct {
 	client           *catoClientData
 	socketSiteClient SocketSiteClient
@@ -877,7 +866,7 @@ func (r *socketSiteResource) parseNativeRange(ctx context.Context, cfg *tf.Socke
 		LocalIP:               localIP,
 		PrimaryManagementIP:   types.StringPointerValue(networkRange.PrimaryManagementIP),
 		SecondaryManagementIP: types.StringPointerValue(networkRange.SecondaryManagementIP),
-		TranslatedSubnet:      nativeRangeTranslatedSubnetFromAPI(networkRange.TranslatedSubnet, networkRange.Subnet),
+		TranslatedSubnet:      types.StringPointerValue(networkRange.TranslatedSubnet),
 		Gateway:               types.StringPointerValue(networkRange.Gateway),
 		RangeType:             types.StringValue(strings.ToUpper(string(networkRange.RangeType))),
 		DhcpSettings:          dhcpSettingsObj,

--- a/internal/provider/resource_site_socket_test.go
+++ b/internal/provider/resource_site_socket_test.go
@@ -205,6 +205,7 @@ func TestSocketSitePrepareInputsTranslatedSubnet(t *testing.T) {
 
 			ctx := context.Background()
 			plan := newSocketSitePlanWithTranslatedSubnet(ctx, t, tt.translatedSubnet)
+			cfg := plan
 			r := &socketSiteResource{client: &catoClientData{}}
 			var diags diag.Diagnostics
 
@@ -214,13 +215,13 @@ func TestSocketSitePrepareInputsTranslatedSubnet(t *testing.T) {
 			}
 			assertTranslatedSubnetPointer(t, addInput.TranslatedSubnet, tt.wantNil, tt.wantValue)
 
-			networkRangeInput := r.prepareNetworkRangeInput(ctx, plan, false, &diags)
+			networkRangeInput := r.prepareNetworkRangeInput(ctx, cfg, plan, false, &diags)
 			if diags.HasError() {
 				t.Fatalf("prepareNetworkRangeInput: %v", diags)
 			}
 			assertTranslatedSubnetPointer(t, networkRangeInput.TranslatedSubnet, tt.wantNil, tt.wantValue)
 
-			socketIfaceInput, _ := r.prepareSocketInterfaceInput(ctx, plan, false, &diags)
+			socketIfaceInput, _ := r.prepareSocketInterfaceInput(ctx, cfg, plan, false, &diags)
 			if diags.HasError() {
 				t.Fatalf("prepareSocketInterfaceInput: %v", diags)
 			}
@@ -228,6 +229,82 @@ func TestSocketSitePrepareInputsTranslatedSubnet(t *testing.T) {
 				t.Fatal("expected LAN input")
 			}
 			assertTranslatedSubnetPointer(t, socketIfaceInput.Lan.TranslatedSubnet, tt.wantNil, tt.wantValue)
+		})
+	}
+}
+
+func TestSocketSitePrepareUpdateInputsTranslatedSubnetFromConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := newSocketSitePlanWithTranslatedSubnet(ctx, t, types.StringValue("10.24.150.0/24"))
+	cfg := newSocketSitePlanWithTranslatedSubnet(ctx, t, types.StringNull())
+	r := &socketSiteResource{client: &catoClientData{}}
+	var diags diag.Diagnostics
+
+	networkRangeInput := r.prepareNetworkRangeInput(ctx, cfg, plan, false, &diags)
+	if diags.HasError() {
+		t.Fatalf("prepareNetworkRangeInput: %v", diags)
+	}
+	if networkRangeInput.TranslatedSubnet != nil {
+		t.Fatalf("expected translated subnet omitted when not in config, got %q", *networkRangeInput.TranslatedSubnet)
+	}
+
+	socketIfaceInput, _ := r.prepareSocketInterfaceInput(ctx, cfg, plan, false, &diags)
+	if diags.HasError() {
+		t.Fatalf("prepareSocketInterfaceInput: %v", diags)
+	}
+	if socketIfaceInput.Lan == nil {
+		t.Fatal("expected LAN input")
+	}
+	if socketIfaceInput.Lan.TranslatedSubnet != nil {
+		t.Fatalf("expected translated subnet omitted when not in config, got %q", *socketIfaceInput.Lan.TranslatedSubnet)
+	}
+}
+
+func TestNativeRangeTranslatedSubnetFromAPI(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		translatedSubnet *string
+		nativeSubnet     string
+		wantNull         bool
+		wantValue        string
+	}{
+		"nil": {
+			wantNull: true,
+		},
+		"empty": {
+			translatedSubnet: stringPtr(""),
+			nativeSubnet:     "10.0.0.0/24",
+			wantNull:         true,
+		},
+		"equals_native": {
+			translatedSubnet: stringPtr("10.0.0.0/24"),
+			nativeSubnet:     "10.0.0.0/24",
+			wantNull:         true,
+		},
+		"distinct": {
+			translatedSubnet: stringPtr("192.168.20.0/24"),
+			nativeSubnet:     "10.0.0.0/24",
+			wantValue:        "192.168.20.0/24",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := nativeRangeTranslatedSubnetFromAPI(tt.translatedSubnet, tt.nativeSubnet)
+			if tt.wantNull {
+				if !got.IsNull() {
+					t.Fatalf("expected null, got %q", got.ValueString())
+				}
+				return
+			}
+			if got.IsNull() || got.ValueString() != tt.wantValue {
+				t.Fatalf("expected %q, got %v", tt.wantValue, got)
+			}
 		})
 	}
 }

--- a/internal/provider/resource_site_socket_test.go
+++ b/internal/provider/resource_site_socket_test.go
@@ -262,53 +262,6 @@ func TestSocketSitePrepareUpdateInputsTranslatedSubnetFromConfig(t *testing.T) {
 	}
 }
 
-func TestNativeRangeTranslatedSubnetFromAPI(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]struct {
-		translatedSubnet *string
-		nativeSubnet     string
-		wantNull         bool
-		wantValue        string
-	}{
-		"nil": {
-			wantNull: true,
-		},
-		"empty": {
-			translatedSubnet: stringPtr(""),
-			nativeSubnet:     "10.0.0.0/24",
-			wantNull:         true,
-		},
-		"equals_native": {
-			translatedSubnet: stringPtr("10.0.0.0/24"),
-			nativeSubnet:     "10.0.0.0/24",
-			wantNull:         true,
-		},
-		"distinct": {
-			translatedSubnet: stringPtr("192.168.20.0/24"),
-			nativeSubnet:     "10.0.0.0/24",
-			wantValue:        "192.168.20.0/24",
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			got := nativeRangeTranslatedSubnetFromAPI(tt.translatedSubnet, tt.nativeSubnet)
-			if tt.wantNull {
-				if !got.IsNull() {
-					t.Fatalf("expected null, got %q", got.ValueString())
-				}
-				return
-			}
-			if got.IsNull() || got.ValueString() != tt.wantValue {
-				t.Fatalf("expected %q, got %v", tt.wantValue, got)
-			}
-		})
-	}
-}
-
 func newSocketSitePlanWithTranslatedSubnet(ctx context.Context, t *testing.T, translatedSubnet types.String) *tf.SocketSite {
 	t.Helper()
 


### PR DESCRIPTION
Omit translated_subnet from update API payloads when it is not set in Terraform config, and normalize API-hydrated state when it matches the native subnet.