### PR TITLE
fix: omit translated_subnet on network range unless in config

### DIFF
--- a/internal/provider/resource_lan_interface.go
+++ b/internal/provider/resource_lan_interface.go
@@ -143,8 +143,10 @@ func (r *lanInterfaceResource) ImportState(ctx context.Context, req resource.Imp
 
 //nolint:gocyclo,funlen,lll
 func (r *lanInterfaceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan LanInterface
+	var cfg, plan LanInterface
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	diags = req.Config.Get(ctx, &cfg)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -172,7 +174,7 @@ func (r *lanInterfaceResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	input := hydrateLanInterfaceAPI(ctx, plan)
+	input := hydrateLanInterfaceAPI(ctx, cfg, plan)
 	tflog.Debug(ctx, "Create.SiteUpdateSocketInterface.request", map[string]interface{}{
 		"request": utils.InterfaceToJSONString(input),
 	})
@@ -291,8 +293,10 @@ func (r *lanInterfaceResource) Read(ctx context.Context, req resource.ReadReques
 
 //nolint:gocyclo,lll
 func (r *lanInterfaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan LanInterface
+	var cfg, plan LanInterface
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	diags = req.Config.Get(ctx, &cfg)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -320,7 +324,7 @@ func (r *lanInterfaceResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	input := hydrateLanInterfaceAPI(ctx, plan)
+	input := hydrateLanInterfaceAPI(ctx, cfg, plan)
 	tflog.Debug(ctx, "lan_interface update", map[string]interface{}{
 		"input": utils.InterfaceToJSONString(input),
 	})
@@ -477,7 +481,7 @@ func (r *lanInterfaceResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 }
 
-func hydrateLanInterfaceAPI(ctx context.Context, plan LanInterface) cato_models.UpdateSocketInterfaceInput {
+func hydrateLanInterfaceAPI(ctx context.Context, cfg, plan LanInterface) cato_models.UpdateSocketInterfaceInput {
 	tflog.Debug(ctx, "lan_interface update", map[string]interface{}{
 		"plan.DestType.String()": utils.InterfaceToJSONString(plan.DestType.ValueString()),
 		"plan.Name.String()":     utils.InterfaceToJSONString(plan.Name.ValueStringPointer()),
@@ -496,7 +500,7 @@ func hydrateLanInterfaceAPI(ctx context.Context, plan LanInterface) cato_models.
 		// Add LAN configuration for non-LAG member interfaces
 		input.Lan = &cato_models.SocketInterfaceLanInput{
 			Subnet:           plan.Subnet.ValueString(),
-			TranslatedSubnet: stringPointerForOptionalInput(plan.TranslatedSubnet),
+			TranslatedSubnet: translatedSubnetForAPIInput(cfg.TranslatedSubnet, plan.TranslatedSubnet),
 			LocalIP:          plan.LocalIP.ValueString(),
 		}
 

--- a/internal/provider/resource_network_range.go
+++ b/internal/provider/resource_network_range.go
@@ -347,7 +347,7 @@ func (r *networkRangeResource) Create(ctx context.Context, req resource.CreateRe
 		Name:             plan.Name.ValueString(),
 		RangeType:        cato_models.SubnetType(plan.RangeType.ValueString()),
 		Subnet:           plan.Subnet.ValueString(),
-		TranslatedSubnet: stringPointerForOptionalInput(plan.TranslatedSubnet),
+		TranslatedSubnet: translatedSubnetForAPIInput(cfg.TranslatedSubnet, plan.TranslatedSubnet),
 		Vlan:             parse.KnownInt64Pointer(plan.Vlan),
 	}
 	// TODO: check if !isHA { // for HA scenario, local IP is not allowed to be modified
@@ -440,7 +440,7 @@ func (r *networkRangeResource) Update(ctx context.Context, req resource.UpdateRe
 		Name:             parse.KnownStringPointer(plan.Name),
 		RangeType:        (*cato_models.SubnetType)(parse.KnownStringPointer(plan.RangeType)),
 		Subnet:           parse.KnownStringPointer(plan.Subnet),
-		TranslatedSubnet: stringPointerForOptionalInput(plan.TranslatedSubnet),
+		TranslatedSubnet: translatedSubnetForAPIInput(cfg.TranslatedSubnet, plan.TranslatedSubnet),
 		Vlan:             parse.KnownInt64Pointer(plan.Vlan),
 	}
 

--- a/internal/provider/resource_site_socket.go
+++ b/internal/provider/resource_site_socket.go
@@ -58,22 +58,6 @@ func NewSocketSiteResource() resource.Resource {
 	return &socketSiteResource{}
 }
 
-func stringPointerForOptionalInput(value types.String) *string {
-	if value.IsNull() || value.IsUnknown() || value.ValueString() == "" {
-		return nil
-	}
-	return value.ValueStringPointer()
-}
-
-// translatedSubnetForAPIInput omits translated_subnet from update payloads when the attribute is not
-// explicitly set in Terraform config, even if plan/state still carry an API-hydrated value.
-func translatedSubnetForAPIInput(configValue, planValue types.String) *string {
-	if configValue.IsNull() || configValue.IsUnknown() {
-		return nil
-	}
-	return stringPointerForOptionalInput(planValue)
-}
-
 type socketSiteResource struct {
 	client           *catoClientData
 	socketSiteClient SocketSiteClient

--- a/internal/provider/translated_subnet_functionality_test.go
+++ b/internal/provider/translated_subnet_functionality_test.go
@@ -42,14 +42,36 @@ func TestHydrateLanInterfaceAPITranslatedSubnet(t *testing.T) {
 				TranslatedSubnet: tt.translatedSubnet,
 				VrrpType:         types.StringNull(),
 			}
+			cfg := plan
 
-			input := hydrateLanInterfaceAPI(context.Background(), plan)
+			input := hydrateLanInterfaceAPI(context.Background(), cfg, plan)
 			if input.Lan == nil {
 				t.Fatal("expected LAN input")
 			}
 			assertTranslatedSubnetPointer(t, input.Lan.TranslatedSubnet, tt.wantNil, tt.wantValue)
 		})
 	}
+}
+
+func TestHydrateLanInterfaceAPIOmitTranslatedSubnetWhenNotInConfig(t *testing.T) {
+	t.Parallel()
+
+	plan := LanInterface{
+		Name:             types.StringValue("lan-1"),
+		DestType:         types.StringValue("LAN"),
+		LocalIP:          types.StringValue("10.12.62.1"),
+		Subnet:           types.StringValue("10.12.62.0/24"),
+		TranslatedSubnet: types.StringValue("10.12.62.0/24"),
+		VrrpType:         types.StringNull(),
+	}
+	cfg := plan
+	cfg.TranslatedSubnet = types.StringNull()
+
+	input := hydrateLanInterfaceAPI(context.Background(), cfg, plan)
+	if input.Lan == nil {
+		t.Fatal("expected LAN input")
+	}
+	assertTranslatedSubnetPointer(t, input.Lan.TranslatedSubnet, true, "")
 }
 
 func assertTranslatedSubnetPointer(t *testing.T, got *string, wantNil bool, wantValue string) {

--- a/internal/provider/translated_subnet_input.go
+++ b/internal/provider/translated_subnet_input.go
@@ -1,0 +1,22 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func stringPointerForOptionalInput(value types.String) *string {
+	if value.IsNull() || value.IsUnknown() || value.ValueString() == "" {
+		return nil
+	}
+	return value.ValueStringPointer()
+}
+
+// translatedSubnetForAPIInput omits translated_subnet from API payloads when the attribute is not
+// explicitly set in Terraform config, even if plan/state still carry an API-hydrated value
+// (e.g. equal to subnet when Static Range Translation is disabled).
+func translatedSubnetForAPIInput(configValue, planValue types.String) *string {
+	if configValue.IsNull() || configValue.IsUnknown() {
+		return nil
+	}
+	return stringPointerForOptionalInput(planValue)
+}

--- a/internal/provider/translated_subnet_input_test.go
+++ b/internal/provider/translated_subnet_input_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestTranslatedSubnetForAPIInput(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cfg, plan types.String
+		wantNil   bool
+		want      string
+	}{
+		"config_null_omits_even_when_plan_has_api_value": {
+			cfg:     types.StringNull(),
+			plan:    types.StringValue("10.12.62.0/24"),
+			wantNil: true,
+		},
+		"config_unknown_omits": {
+			cfg:     types.StringUnknown(),
+			plan:    types.StringValue("10.12.62.0/24"),
+			wantNil: true,
+		},
+		"config_present_empty_plan_empty": {
+			cfg:     types.StringValue(""),
+			plan:    types.StringValue(""),
+			wantNil: true,
+		},
+		"config_present_forwards_non_empty_plan": {
+			cfg:     types.StringValue("10.0.0.0/24"),
+			plan:    types.StringValue("10.1.0.0/24"),
+			wantNil: false,
+			want:    "10.1.0.0/24",
+		},
+		"config_present_plan_empty": {
+			cfg:     types.StringValue("10.0.0.0/24"),
+			plan:    types.StringValue(""),
+			wantNil: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := translatedSubnetForAPIInput(tt.cfg, tt.plan)
+			assertTranslatedSubnetPointer(t, got, tt.wantNil, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Apply the same config-vs-plan rule used for socket_site updates to cato_network_range and cato_lan_interface so API payloads do not send translatedSubnet when Static Range Translation is off and the value only comes from plan/state. Centralize helpers in translated_subnet_input.go.