### PR TITLE
fix(ipsec): preserve IDs on PSK updates

### DIFF
--- a/docs/resources/ipsec_site.md
+++ b/docs/resources/ipsec_site.md
@@ -136,7 +136,7 @@ Optional:
 
 Required:
 
-- `psk` (String) psk
+- `psk` (String, Sensitive) psk
 
 Optional:
 
@@ -202,7 +202,7 @@ Optional:
 
 Required:
 
-- `psk` (String) psk
+- `psk` (String, Sensitive) psk
 
 Optional:
 

--- a/internal/provider/hydrate_ipsec_site_api.go
+++ b/internal/provider/hydrate_ipsec_site_api.go
@@ -181,6 +181,121 @@ func hydrateAddIpsecIkeV2SiteTunnels(ctx context.Context, plan SiteIpsecIkeV2) (
 	return result, diags
 }
 
+// hydrateUpdateIpsecIkeV2SiteTunnels builds the update input and restores computed
+// tunnel IDs from prior state when Terraform marks nested computed values unknown.
+func hydrateUpdateIpsecIkeV2SiteTunnels(
+	ctx context.Context,
+	plan SiteIpsecIkeV2,
+	state SiteIpsecIkeV2,
+) (cato_models.UpdateIpsecIkeV2SiteTunnelsInput, diag.Diagnostics) {
+	result, diags := hydrateAddIpsecIkeV2SiteTunnels(ctx, plan)
+	if diags.HasError() {
+		return result.update, diags
+	}
+
+	stateIPSec := AddIpsecIkeV2SiteTunnelsInput{}
+	diags = append(diags, state.IPSec.As(ctx, &stateIPSec, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return result.update, diags
+	}
+
+	diags = append(diags, restoreIpsecTunnelIDs(ctx, result.update.Primary, stateIPSec.Primary, "primary")...)
+	diags = append(diags, restoreIpsecTunnelIDs(ctx, result.update.Secondary, stateIPSec.Secondary, "secondary")...)
+
+	return result.update, diags
+}
+
+func restoreIpsecTunnelIDs(
+	ctx context.Context,
+	update *cato_models.UpdateIpsecIkeV2TunnelsInput,
+	stateGroup basetypes.ObjectValue,
+	groupName string,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if update == nil || len(update.Tunnels) == 0 {
+		return diags
+	}
+
+	stateTunnelIDs, stateDiags := ipsecTunnelIDsFromState(ctx, stateGroup)
+	diags = append(diags, stateDiags...)
+	if diags.HasError() {
+		return diags
+	}
+
+	for index, tunnel := range update.Tunnels {
+		if tunnel.TunnelID != "" {
+			continue
+		}
+
+		if index < len(stateTunnelIDs) && stateTunnelIDs[index] != "" {
+			tunnel.TunnelID = stateTunnelIDs[index]
+			continue
+		}
+
+		if derivedID, ok := positionalIpsecTunnelID(groupName, index); ok {
+			tunnel.TunnelID = derivedID
+			continue
+		}
+
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Missing IPSec tunnel ID",
+			"The provider could not determine a valid tunnel ID for the "+
+				groupName+" tunnel. IPSec supports at most three tunnels per group.",
+		))
+	}
+
+	return diags
+}
+
+func ipsecTunnelIDsFromState(
+	ctx context.Context,
+	stateGroup basetypes.ObjectValue,
+) ([]cato_models.IPSecV2InterfaceID, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if stateGroup.IsNull() || stateGroup.IsUnknown() {
+		return nil, diags
+	}
+
+	group := AddIpsecIkeV2TunnelsInput{}
+	diags = append(diags, stateGroup.As(ctx, &group, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() || group.Tunnels.IsNull() || group.Tunnels.IsUnknown() {
+		return nil, diags
+	}
+
+	stateTunnels := make([]basetypes.ObjectValue, 0, len(group.Tunnels.Elements()))
+	diags = append(diags, group.Tunnels.ElementsAs(ctx, &stateTunnels, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	tunnelIDs := make([]cato_models.IPSecV2InterfaceID, len(stateTunnels))
+	for index, stateTunnelValue := range stateTunnels {
+		stateTunnel := AddIpsecIkeV2TunnelInput{}
+		diags = append(diags, stateTunnelValue.As(ctx, &stateTunnel, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		if !stateTunnel.TunnelID.IsNull() && !stateTunnel.TunnelID.IsUnknown() {
+			tunnelIDs[index] = cato_models.IPSecV2InterfaceID(stateTunnel.TunnelID.ValueString())
+		}
+	}
+
+	return tunnelIDs, diags
+}
+
+func positionalIpsecTunnelID(groupName string, index int) (cato_models.IPSecV2InterfaceID, bool) {
+	tunnelIDs := map[string][]cato_models.IPSecV2InterfaceID{
+		"primary":   {"PRIMARY1", "PRIMARY2", "PRIMARY3"},
+		"secondary": {"SECONDARY1", "SECONDARY2", "SECONDARY3"},
+	}
+
+	groupIDs, ok := tunnelIDs[groupName]
+	if !ok || index < 0 || index >= len(groupIDs) {
+		return "", false
+	}
+	return groupIDs[index], true
+}
+
 // hydrateUpdateIpsecIkeV2SiteGeneralDetails takes the plan and returns UpdateIpsecIkeV2SiteGeneralDetailsInput
 //
 //nolint:gocyclo,funlen

--- a/internal/provider/hydrate_ipsec_site_api_test.go
+++ b/internal/provider/hydrate_ipsec_site_api_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	cato_models "github.com/catonetworks/cato-go-sdk/models"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestHydrateUpdateIpsecIkeV2SiteTunnelsRestoresComputedTunnelIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := SiteIpsecIkeV2{
+		IPSec: testIPSecObject(
+			testIPSecTunnelGroup(types.StringUnknown(), "new-primary-psk"),
+			testIPSecTunnelGroup(types.StringValue("SECONDARY2"), "new-secondary-psk"),
+		),
+	}
+	state := SiteIpsecIkeV2{
+		IPSec: testIPSecObject(
+			testIPSecTunnelGroup(types.StringValue("PRIMARY1"), "old-primary-psk"),
+			testIPSecTunnelGroup(types.StringValue("SECONDARY1"), "old-secondary-psk"),
+		),
+	}
+
+	input, diags := hydrateUpdateIpsecIkeV2SiteTunnels(ctx, plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if got := input.Primary.Tunnels[0].TunnelID; got != cato_models.IPSecV2InterfaceID("PRIMARY1") {
+		t.Fatalf("expected primary tunnel ID PRIMARY1 from state, got %q", got)
+	}
+	if got := input.Primary.Tunnels[0].Psk; got == nil || *got != "new-primary-psk" {
+		t.Fatalf("expected updated primary PSK, got %v", got)
+	}
+	if got := input.Secondary.Tunnels[0].TunnelID; got != cato_models.IPSecV2InterfaceID("SECONDARY2") {
+		t.Fatalf("expected known planned secondary tunnel ID SECONDARY2, got %q", got)
+	}
+}
+
+func TestHydrateUpdateIpsecIkeV2SiteTunnelsDerivesMissingTunnelID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := SiteIpsecIkeV2{
+		IPSec: testIPSecObject(
+			testIPSecTunnelGroup(types.StringUnknown(), "new-primary-psk"),
+			types.ObjectNull(IpsecTunnelsResourceAttrTypes),
+		),
+	}
+	state := SiteIpsecIkeV2{
+		IPSec: testIPSecObject(
+			testIPSecTunnelGroup(types.StringNull(), "old-primary-psk"),
+			types.ObjectNull(IpsecTunnelsResourceAttrTypes),
+		),
+	}
+
+	input, diags := hydrateUpdateIpsecIkeV2SiteTunnels(ctx, plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got := input.Primary.Tunnels[0].TunnelID; got != cato_models.IPSecV2InterfaceID("PRIMARY1") {
+		t.Fatalf("expected derived primary tunnel ID PRIMARY1, got %q", got)
+	}
+}
+
+func testIPSecObject(primary, secondary types.Object) types.Object {
+	return types.ObjectValueMust(IpsecResourceAttrTypes, map[string]attr.Value{
+		"site_id":             types.StringValue("site-123"),
+		"primary":             primary,
+		"secondary":           secondary,
+		"connection_mode":     types.StringValue("RESPONDER_ONLY"),
+		"identification_type": types.StringValue("FQDN"),
+		"init_message":        types.ObjectNull(IpsecMessageResourceAttrTypes),
+		"auth_message":        types.ObjectNull(IpsecMessageResourceAttrTypes),
+		"network_ranges":      types.ListNull(types.StringType),
+	})
+}
+
+func testIPSecTunnelGroup(tunnelID types.String, psk string) types.Object {
+	tunnel := types.ObjectValueMust(TunnelResourceAttrTypes, map[string]attr.Value{
+		"tunnel_id":       tunnelID,
+		"public_site_ip":  types.StringNull(),
+		"private_cato_ip": types.StringNull(),
+		"private_site_ip": types.StringNull(),
+		"psk":             types.StringValue(psk),
+		"last_mile_bw":    types.ObjectNull(LastMileBwResourceAttrTypes),
+	})
+
+	return types.ObjectValueMust(IpsecTunnelsResourceAttrTypes, map[string]attr.Value{
+		"destination_type":  types.StringValue("FQDN"),
+		"public_cato_ip_id": types.StringNull(),
+		"pop_location_id":   types.StringNull(),
+		"tunnels": types.ListValueMust(
+			types.ObjectType{AttrTypes: TunnelResourceAttrTypes},
+			[]attr.Value{tunnel},
+		),
+	})
+}

--- a/internal/provider/resource_site_ipsec.go
+++ b/internal/provider/resource_site_ipsec.go
@@ -170,6 +170,7 @@ func (r *siteIpsecResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										"psk": schema.StringAttribute{
 											Description: "psk",
 											Required:    true,
+											Sensitive:   true,
 										},
 										"last_mile_bw": schema.SingleNestedAttribute{
 											Description: "lastmilebw",
@@ -249,6 +250,7 @@ func (r *siteIpsecResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										"psk": schema.StringAttribute{
 											Description: "psk",
 											Required:    true,
+											Sensitive:   true,
 										},
 										"last_mile_bw": schema.SingleNestedAttribute{
 											Description: "lastmilebw",
@@ -539,9 +541,7 @@ func (r *siteIpsecResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	tflog.Debug(ctx, "Create.SiteAddIpsecIkeV2SiteTunnels.request", map[string]interface{}{
-		"request": utils.InterfaceToJSONString(tunnelInputs.add),
-	})
+	tflog.Debug(ctx, "Create.SiteAddIpsecIkeV2SiteTunnels.request")
 	tunnelData, errIPSec := r.client.catov2.SiteAddIpsecIkeV2SiteTunnels(ctx, siteID, tunnelInputs.add, r.client.AccountId)
 	tflog.Debug(ctx, "Create.SiteAddIpsecIkeV2SiteTunnels.response", map[string]interface{}{
 		"response": utils.InterfaceToJSONString(tunnelData),
@@ -633,6 +633,19 @@ func (r *siteIpsecResource) Read(ctx context.Context, req resource.ReadRequest, 
 func (r *siteIpsecResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan SiteIpsecIkeV2
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state SiteIpsecIkeV2
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tunnelInput, diags := hydrateUpdateIpsecIkeV2SiteTunnels(ctx, plan, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -747,18 +760,9 @@ func (r *siteIpsecResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	// Hydrate API input for tunnels
-	tunnelInputs, diags := hydrateAddIpsecIkeV2SiteTunnels(ctx, plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	if !plan.IPSec.IsNull() {
-		tflog.Debug(ctx, "Update.SiteUpdateIpsecIkeV2SiteTunnels.request", map[string]interface{}{
-			"request": utils.InterfaceToJSONString(tunnelInputs.update),
-		})
-		tunnelData, errIPSec := r.client.catov2.SiteUpdateIpsecIkeV2SiteTunnels(ctx, siteID, tunnelInputs.update, r.client.AccountId)
+		tflog.Debug(ctx, "Update.SiteUpdateIpsecIkeV2SiteTunnels.request")
+		tunnelData, errIPSec := r.client.catov2.SiteUpdateIpsecIkeV2SiteTunnels(ctx, siteID, tunnelInput, r.client.AccountId)
 		tflog.Debug(ctx, "Update.SiteUpdateIpsecIkeV2SiteTunnels.response", map[string]interface{}{
 			"response": utils.InterfaceToJSONString(tunnelData),
 		})


### PR DESCRIPTION
Restore missing computed tunnel IDs before updates so responder-only FQDN sites do not send invalid API input. Mark PSKs sensitive and keep them out of debug logs.

Closes #29