### PR TITLE
go-sdk update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/Yamashou/gqlgenc v0.30.2
-	github.com/catonetworks/cato-go-sdk v0.3.3-0.20260804084537-f4206a8a8828
+	github.com/catonetworks/cato-go-sdk v0.3.3-0.20260807121143-631dfa658cc1
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/catenacyber/perfsprint v0.10.1 h1:u7Riei30bk46XsG8nknMhKLXG9BcXz3+3tl
 github.com/catenacyber/perfsprint v0.10.1/go.mod h1:DJTGsi/Zufpuus6XPGJyKOTMELe347o6akPvWG9Zcsc=
 github.com/catonetworks/cato-go-sdk v0.3.3-0.20260804084537-f4206a8a8828 h1:/BMxQUKGyCLaldRrl8DOtsQ1r8l/rc1b7d+OX+DHJAk=
 github.com/catonetworks/cato-go-sdk v0.3.3-0.20260804084537-f4206a8a8828/go.mod h1:XABVlGB2yK7CISvbrZtHovAQuKPmsobB2XGRGy2Jj3s=
+github.com/catonetworks/cato-go-sdk v0.3.3-0.20260807121143-631dfa658cc1 h1:yDgHohMtGSX1dlaP8j+nOyPaPkpHHZ6Im6AGhInjcUo=
+github.com/catonetworks/cato-go-sdk v0.3.3-0.20260807121143-631dfa658cc1/go.mod h1:XABVlGB2yK7CISvbrZtHovAQuKPmsobB2XGRGy2Jj3s=
 github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNrUcc=
 github.com/ccojocar/zxcvbn-go v1.0.4/go.mod h1:3GxGX+rHmueTUMvm5ium7irpyjmm7ikxYFOSJB21Das=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
Bump go-sdk to v0.3.3-0.20260807121143-631dfa658cc1