### PR TITLE
fix: skip unchanged IPSec network range

### DIFF
--- a/internal/provider/resource_site_ipsec.go
+++ b/internal/provider/resource_site_ipsec.go
@@ -656,7 +656,7 @@ func (r *siteIpsecResource) Update(ctx context.Context, req resource.UpdateReque
 		SiteLocation: &cato_models.UpdateSiteLocationInput{},
 	}
 
-	inputUpdateNetworkRange := cato_models.UpdateNetworkRangeInput{}
+	inputUpdateNetworkRange, updateNetworkRange := prepareIpsecNetworkRangeUpdate(plan, state)
 
 	// setting input site location
 	if !plan.SiteLocation.IsNull() {
@@ -671,8 +671,6 @@ func (r *siteIpsecResource) Update(ctx context.Context, req resource.UpdateReque
 		inputSiteGeneral.SiteLocation.Timezone = siteLocationInput.Timezone.ValueStringPointer()
 	}
 
-	inputUpdateNetworkRange.Subnet = plan.NativeNetworkRange.ValueStringPointer()
-	inputUpdateNetworkRange.TranslatedSubnet = plan.NativeNetworkRange.ValueStringPointer()
 	inputSiteGeneral.Name = plan.Name.ValueStringPointer()
 	inputSiteGeneral.SiteType = (*cato_models.SiteType)(plan.SiteType.ValueStringPointer())
 	inputSiteGeneral.Description = plan.Description.ValueStringPointer()
@@ -697,17 +695,24 @@ func (r *siteIpsecResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	tflog.Debug(ctx, "Update.SiteUpdateNetworkRange.request", map[string]interface{}{
-		"request": utils.InterfaceToJSONString(inputUpdateNetworkRange),
-	})
-	// TODO, look at why response object does not resolve
-	_, err = r.client.catov2.SiteUpdateNetworkRange(ctx, plan.NativeNetworkRangeID.ValueString(), inputUpdateNetworkRange, r.client.AccountId)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Catov2 API SiteUpdateNetworkRange error",
-			err.Error(),
+	if updateNetworkRange {
+		tflog.Debug(ctx, "Update.SiteUpdateNetworkRange.request", map[string]interface{}{
+			"request": utils.InterfaceToJSONString(inputUpdateNetworkRange),
+		})
+		// TODO, look at why response object does not resolve
+		_, err = r.client.catov2.SiteUpdateNetworkRange(
+			ctx,
+			plan.NativeNetworkRangeID.ValueString(),
+			*inputUpdateNetworkRange,
+			r.client.AccountId,
 		)
-		return
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Catov2 API SiteUpdateNetworkRange error",
+				err.Error(),
+			)
+			return
+		}
 	}
 
 	// Hydrate API input for IPSec general details
@@ -798,6 +803,16 @@ func (r *siteIpsecResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+}
+
+func prepareIpsecNetworkRangeUpdate(plan, state SiteIpsecIkeV2) (*cato_models.UpdateNetworkRangeInput, bool) {
+	if plan.NativeNetworkRange.Equal(state.NativeNetworkRange) {
+		return nil, false
+	}
+
+	return &cato_models.UpdateNetworkRangeInput{
+		Subnet: plan.NativeNetworkRange.ValueStringPointer(),
+	}, true
 }
 
 func (r *siteIpsecResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_site_ipsec_test.go
+++ b/internal/provider/resource_site_ipsec_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareIpsecNetworkRangeUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		planRange  string
+		stateRange string
+		wantUpdate bool
+	}{
+		"unchanged range skips update": {
+			planRange:  "10.0.0.0/24",
+			stateRange: "10.0.0.0/24",
+			wantUpdate: false,
+		},
+		"changed range prepares update": {
+			planRange:  "10.0.1.0/24",
+			stateRange: "10.0.0.0/24",
+			wantUpdate: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			input, update := prepareIpsecNetworkRangeUpdate(
+				SiteIpsecIkeV2{NativeNetworkRange: types.StringValue(tt.planRange)},
+				SiteIpsecIkeV2{NativeNetworkRange: types.StringValue(tt.stateRange)},
+			)
+
+			require.Equal(t, tt.wantUpdate, update)
+			if !tt.wantUpdate {
+				require.Nil(t, input)
+				return
+			}
+
+			require.NotNil(t, input)
+			require.Equal(t, tt.planRange, *input.Subnet)
+			require.Nil(t, input.TranslatedSubnet)
+		})
+	}
+}


### PR DESCRIPTION
Omit translatedSubnet because cato_ipsec_site has no schema-backed configuration for Static Range Translation.

Refs ENG-204334