### PR TITLE
fix: pin omitted system rules during reorder

### DIFF
--- a/internal/provider/policy_reorder_bulk.go
+++ b/internal/provider/policy_reorder_bulk.go
@@ -29,6 +29,7 @@ type BulkPolicyRuleRow struct {
 	RuleID      string
 	RuleName    string
 	Index       int64
+	IsSystem    bool
 }
 
 // BulkPlannedRuleIndex is one rule placement from Terraform rule_data.
@@ -36,6 +37,18 @@ type BulkPlannedRuleIndex struct {
 	SectionName    string
 	RuleName       string
 	IndexInSection int64
+}
+
+func policyElementHasProperty(
+	properties []cato_models.PolicyElementPropertiesEnum,
+	target cato_models.PolicyElementPropertiesEnum,
+) bool {
+	for _, property := range properties {
+		if property == target {
+			return true
+		}
+	}
+	return false
 }
 
 func sectionIDSet(sections []BulkPolicySectionRef) map[string]struct{} {
@@ -96,6 +109,68 @@ func ruleNameToIDGlobal(rules []BulkPolicyRuleRow) map[string]string {
 	return out
 }
 
+func validateSystemRulesOmitted(rules []BulkPolicyRuleRow, planned []BulkPlannedRuleIndex) error {
+	systemRulesByName := make(map[string]BulkPolicyRuleRow)
+	for _, rule := range rules {
+		if rule.IsSystem {
+			systemRulesByName[rule.RuleName] = rule
+		}
+	}
+
+	for _, placement := range planned {
+		systemRule, ok := systemRulesByName[placement.RuleName]
+		if !ok {
+			continue
+		}
+		return fmt.Errorf(
+			"system rule %q in section %q cannot be managed by rule_data; "+
+				"omit system rules to pin them automatically",
+			placement.RuleName,
+			systemRule.SectionName,
+		)
+	}
+
+	return nil
+}
+
+func mergePinnedSystemRules(
+	sectionName string,
+	apiRules []BulkPolicyRuleRow,
+	movableIDs []string,
+) ([]string, error) {
+	systemRulesByPosition := make(map[int]BulkPolicyRuleRow)
+	for position, rule := range apiRules {
+		if rule.IsSystem {
+			systemRulesByPosition[position] = rule
+		}
+	}
+
+	finalIDs := make([]string, len(movableIDs)+len(systemRulesByPosition))
+	for position, systemRule := range systemRulesByPosition {
+		if position >= len(finalIDs) {
+			return nil, fmt.Errorf(
+				"system rule %q cannot remain at position %d in section %q with only %d rules",
+				systemRule.RuleName,
+				position,
+				sectionName,
+				len(finalIDs),
+			)
+		}
+	}
+
+	nextMovable := 0
+	for position := range finalIDs {
+		if systemRule, pinned := systemRulesByPosition[position]; pinned {
+			finalIDs[position] = systemRule.RuleID
+			continue
+		}
+		finalIDs[position] = movableIDs[nextMovable]
+		nextMovable++
+	}
+
+	return finalIDs, nil
+}
+
 func buildSectionReorderInput(
 	sec BulkPolicySectionRef,
 	apiRules []BulkPolicyRuleRow,
@@ -129,6 +204,9 @@ func buildSectionReorderInput(
 
 	tailIDs := make([]string, 0, len(apiRules))
 	for _, r := range apiRules {
+		if r.IsSystem {
+			continue
+		}
 		if _, ok := plannedNames[r.RuleName]; ok {
 			continue
 		}
@@ -138,7 +216,11 @@ func buildSectionReorderInput(
 		tailIDs = append(tailIDs, r.RuleID)
 	}
 
-	finalIDs := append(append([]string{}, orderedPlannedIDs...), tailIDs...)
+	movableIDs := append(append([]string{}, orderedPlannedIDs...), tailIDs...)
+	finalIDs, err := mergePinnedSystemRules(sec.Name, apiRules, movableIDs)
+	if err != nil {
+		return nil, err
+	}
 
 	ruleInputs := make([]*cato_models.PolicyReorderRuleInput, 0, len(finalIDs))
 	for _, rid := range finalIDs {
@@ -163,8 +245,9 @@ func buildSectionReorderInput(
 }
 
 // buildPolicyReorderInput builds a full PolicyReorderInput from the current API
-// snapshot plus Terraform planned indices. Planned rules are stacked first in
-// index_in_section order; remaining rules in the section keep their relative API order.
+// snapshot plus Terraform planned indices. System rules retain their current section and
+// absolute position. Movable planned rules are stacked in index_in_section order, then
+// remaining movable rules in the section keep their relative API order.
 // Every section from the index must appear in the output (WAN and IF return
 // reorderPolicyMissingSections if any section is omitted), including sections whose
 // final rule list is empty after moves.
@@ -173,6 +256,10 @@ func buildPolicyReorderInput(
 	rules []BulkPolicyRuleRow,
 	planned []BulkPlannedRuleIndex,
 ) (cato_models.PolicyReorderInput, error) {
+	if err := validateSystemRulesOmitted(rules, planned); err != nil {
+		return cato_models.PolicyReorderInput{}, err
+	}
+
 	sectionIDs := sectionIDSet(sections)
 	rulesBySectionID, err := indexRulesBySectionID(sectionIDs, rules)
 	if err != nil {

--- a/internal/provider/policy_reorder_bulk_test.go
+++ b/internal/provider/policy_reorder_bulk_test.go
@@ -31,6 +31,130 @@ func TestBuildPolicyReorderInput_twoRulesSwapOrder(t *testing.T) {
 	require.Equal(t, "r1", in.Sections[0].Rules[1].Ref.Input)
 }
 
+func TestBuildPolicyReorderInput_pinsOmittedSystemRule(t *testing.T) {
+	t.Parallel()
+	sections := []BulkPolicySectionRef{{ID: "s1", Name: "Sec"}}
+	rules := []BulkPolicyRuleRow{
+		{SectionID: "s1", SectionName: "Sec", RuleID: "system", RuleName: "System", Index: 0, IsSystem: true},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r1", RuleName: "A", Index: 1},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r2", RuleName: "B", Index: 2},
+	}
+	planned := []BulkPlannedRuleIndex{
+		{SectionName: "Sec", RuleName: "B", IndexInSection: 1},
+		{SectionName: "Sec", RuleName: "A", IndexInSection: 2},
+	}
+
+	in, err := buildPolicyReorderInput(sections, rules, planned)
+
+	require.NoError(t, err)
+	require.Len(t, in.Sections, 1)
+	require.Len(t, in.Sections[0].Rules, 3)
+	require.Equal(t, "system", in.Sections[0].Rules[0].Ref.Input)
+	require.Equal(t, "r2", in.Sections[0].Rules[1].Ref.Input)
+	require.Equal(t, "r1", in.Sections[0].Rules[2].Ref.Input)
+}
+
+func TestBuildPolicyReorderInput_rejectsSystemRuleIncludedAtCurrentPosition(t *testing.T) {
+	t.Parallel()
+	sections := []BulkPolicySectionRef{{ID: "s1", Name: "Sec"}}
+	rules := []BulkPolicyRuleRow{
+		{SectionID: "s1", SectionName: "Sec", RuleID: "system", RuleName: "System", Index: 0, IsSystem: true},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r1", RuleName: "A", Index: 1},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r2", RuleName: "B", Index: 2},
+	}
+	planned := []BulkPlannedRuleIndex{
+		{SectionName: "Sec", RuleName: "System", IndexInSection: 1},
+		{SectionName: "Sec", RuleName: "B", IndexInSection: 2},
+		{SectionName: "Sec", RuleName: "A", IndexInSection: 3},
+	}
+
+	_, err := buildPolicyReorderInput(sections, rules, planned)
+
+	require.ErrorContains(t, err, `system rule "System" in section "Sec" cannot be managed by rule_data`)
+	require.ErrorContains(t, err, "omit system rules to pin them automatically")
+}
+
+func TestBuildPolicyReorderInput_rejectsSameSectionSystemRuleMove(t *testing.T) {
+	t.Parallel()
+	sections := []BulkPolicySectionRef{{ID: "s1", Name: "Sec"}}
+	rules := []BulkPolicyRuleRow{
+		{SectionID: "s1", SectionName: "Sec", RuleID: "system", RuleName: "System", Index: 0, IsSystem: true},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r1", RuleName: "A", Index: 1},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r2", RuleName: "B", Index: 2},
+	}
+	planned := []BulkPlannedRuleIndex{
+		{SectionName: "Sec", RuleName: "B", IndexInSection: 1},
+		{SectionName: "Sec", RuleName: "System", IndexInSection: 2},
+		{SectionName: "Sec", RuleName: "A", IndexInSection: 3},
+	}
+
+	_, err := buildPolicyReorderInput(sections, rules, planned)
+
+	require.ErrorContains(t, err, `system rule "System" in section "Sec" cannot be managed by rule_data`)
+	require.ErrorContains(t, err, "omit system rules to pin them automatically")
+}
+
+func TestBuildPolicyReorderInput_pinsSystemRuleAtMiddlePosition(t *testing.T) {
+	t.Parallel()
+	sections := []BulkPolicySectionRef{{ID: "s1", Name: "Sec"}}
+	rules := []BulkPolicyRuleRow{
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r1", RuleName: "A", Index: 0},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "system", RuleName: "System", Index: 1, IsSystem: true},
+		{SectionID: "s1", SectionName: "Sec", RuleID: "r2", RuleName: "B", Index: 2},
+	}
+	planned := []BulkPlannedRuleIndex{
+		{SectionName: "Sec", RuleName: "B", IndexInSection: 1},
+		{SectionName: "Sec", RuleName: "A", IndexInSection: 2},
+	}
+
+	in, err := buildPolicyReorderInput(sections, rules, planned)
+
+	require.NoError(t, err)
+	require.Len(t, in.Sections[0].Rules, 3)
+	require.Equal(t, "r2", in.Sections[0].Rules[0].Ref.Input)
+	require.Equal(t, "system", in.Sections[0].Rules[1].Ref.Input)
+	require.Equal(t, "r1", in.Sections[0].Rules[2].Ref.Input)
+}
+
+func TestBuildPolicyReorderInput_rejectsSystemRuleSectionMove(t *testing.T) {
+	t.Parallel()
+	sections := []BulkPolicySectionRef{
+		{ID: "s1", Name: "SecA"},
+		{ID: "s2", Name: "SecB"},
+	}
+	rules := []BulkPolicyRuleRow{
+		{SectionID: "s1", SectionName: "SecA", RuleID: "system", RuleName: "System", Index: 0, IsSystem: true},
+	}
+	planned := []BulkPlannedRuleIndex{
+		{SectionName: "SecB", RuleName: "System", IndexInSection: 1},
+	}
+
+	_, err := buildPolicyReorderInput(sections, rules, planned)
+
+	require.ErrorContains(t, err, `system rule "System" in section "SecA" cannot be managed by rule_data`)
+}
+
+func TestBuildPolicyReorderInput_errorsWhenSystemPositionCannotBeRetained(t *testing.T) {
+	t.Parallel()
+	sections := []BulkPolicySectionRef{
+		{ID: "s1", Name: "SecA"},
+		{ID: "s2", Name: "SecB"},
+	}
+	rules := []BulkPolicyRuleRow{
+		{SectionID: "s1", SectionName: "SecA", RuleID: "r1", RuleName: "A", Index: 0},
+		{SectionID: "s1", SectionName: "SecA", RuleID: "r2", RuleName: "B", Index: 1},
+		{SectionID: "s1", SectionName: "SecA", RuleID: "system", RuleName: "System", Index: 2, IsSystem: true},
+	}
+	planned := []BulkPlannedRuleIndex{
+		{SectionName: "SecB", RuleName: "A", IndexInSection: 1},
+		{SectionName: "SecB", RuleName: "B", IndexInSection: 2},
+	}
+
+	_, err := buildPolicyReorderInput(sections, rules, planned)
+
+	require.ErrorContains(t, err, `system rule "System" cannot remain at position 2`)
+}
+
 func TestBuildPolicyReorderInput_includesEmptySection(t *testing.T) {
 	t.Parallel()
 	sections := []BulkPolicySectionRef{

--- a/internal/provider/resource_internet_fw_rules_index.go
+++ b/internal/provider/resource_internet_fw_rules_index.go
@@ -609,6 +609,10 @@ func (r *ifwRulesIndexResource) moveIfwRulesAndSections(
 				RuleID:      item.Rule.ID,
 				RuleName:    item.Rule.Name,
 				Index:       item.Rule.Index,
+				IsSystem: policyElementHasProperty(
+					item.Properties,
+					cato_models.PolicyElementPropertiesEnumSystem,
+				),
 			})
 		}
 

--- a/internal/provider/resource_wan_fw_rules_index.go
+++ b/internal/provider/resource_wan_fw_rules_index.go
@@ -488,6 +488,10 @@ func (r *wanRulesIndexResource) moveWanRulesAndSections(
 				RuleID:      item.Rule.ID,
 				RuleName:    item.Rule.Name,
 				Index:       item.Rule.Index,
+				IsSystem: policyElementHasProperty(
+					item.Properties,
+					cato_models.PolicyElementPropertiesEnumSystem,
+				),
 			})
 		}
 


### PR DESCRIPTION
Keep immutable system rules at their API positions and reject explicit rule_data entries before backend validation can fail.