### PR TITLE
v0.0.95

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=catonetworks
 PKG_NAME=cato
 BINARY=terraform-provider-${PKG_NAME}
-VERSION=0.0.94
+VERSION=0.0.95
 
 # Mac Intel Chip
 # OS_ARCH=darwin_amd64

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.95 (2026-08-13)
+
+### Changed
+- Updated socket site state hydration to use site general details and the dedicated socket configuration query instead of the account snapshot query.
+- Updated the Cato Go SDK dependency to v0.3.3.
+
+### Fixed
+- Fixed internet firewall rule index updates to skip section moves for sections containing immutable system rules while preserving their policy positions.
+
+### Tests
+- Added unit and acceptance coverage for socket configuration hydration and unit coverage for protected internet firewall section moves.
+
 ## 0.0.94 (2026-08-11)
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/Yamashou/gqlgenc v0.30.2
-	github.com/catonetworks/cato-go-sdk v0.3.3-0.20260812133329-c30ad9142a19
+	github.com/catonetworks/cato-go-sdk v0.3.3
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/catonetworks/cato-go-sdk v0.3.3-0.20260807121143-631dfa658cc1 h1:yDgH
 github.com/catonetworks/cato-go-sdk v0.3.3-0.20260807121143-631dfa658cc1/go.mod h1:XABVlGB2yK7CISvbrZtHovAQuKPmsobB2XGRGy2Jj3s=
 github.com/catonetworks/cato-go-sdk v0.3.3-0.20260812133329-c30ad9142a19 h1:ReycImklLyFvAjPf55WZA80CyeN+59a3POQK3ji9kEM=
 github.com/catonetworks/cato-go-sdk v0.3.3-0.20260812133329-c30ad9142a19/go.mod h1:XABVlGB2yK7CISvbrZtHovAQuKPmsobB2XGRGy2Jj3s=
+github.com/catonetworks/cato-go-sdk v0.3.3 h1:A7VbWPUmnH1ZnQbKtnlGtoF6gZXLyYdsxYcWWoSArZ4=
+github.com/catonetworks/cato-go-sdk v0.3.3/go.mod h1:XABVlGB2yK7CISvbrZtHovAQuKPmsobB2XGRGy2Jj3s=
 github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNrUcc=
 github.com/ccojocar/zxcvbn-go v1.0.4/go.mod h1:3GxGX+rHmueTUMvm5ium7irpyjmm7ikxYFOSJB21Das=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	version string = "0.0.94"
+	version string = "0.0.95"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Prepare provider release v0.0.95.
- Pin `github.com/catonetworks/cato-go-sdk` to v0.3.3.

## Changelog

### Changed
- Updated socket site state hydration to use site general details and the dedicated socket configuration query instead of the account snapshot query.
- Updated the Cato Go SDK dependency to v0.3.3.

### Fixed
- Fixed internet firewall rule index updates to skip section moves for sections containing immutable system rules while preserving their policy positions.

### Tests
- Added unit and acceptance coverage for socket configuration hydration and unit coverage for protected internet firewall section moves.

## Test plan
- [x] `make sort-imports`
- [x] `make docs`
- [x] `make test`
- [x] `make lint`
- [x] `make vul`