### PR TITLE
v0.0.96

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=catonetworks
 PKG_NAME=cato
 BINARY=terraform-provider-${PKG_NAME}
-VERSION=0.0.95
+VERSION=0.0.96
 
 # Mac Intel Chip
 # OS_ARCH=darwin_amd64

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.0.96 (2026-08-18)
+
+### Added
+- Added `cato_lf_sub_policy` and `cato_bulk_lf_move_rule` resources for managing LAN Firewall sub-policies and parent-scoped policy ordering.
+
+### Changed
+- Extended LAN Firewall section, network rule, and firewall rule handling to support sub-policy placement and ordering.
+
+### Fixed
+- Hardened LAN policy lifecycle and state hydration for omitted rule maps, imported sub-policy positions, transient reads, and mutation status errors.
+
+### Tests
+- Added unit and acceptance coverage for LAN Firewall sub-policy lifecycle, rule ordering, and network and firewall rule behavior.
+
 ## 0.0.95 (2026-08-13)
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	version string = "0.0.95"
+	version string = "0.0.96"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Bump provider version from 0.0.95 to 0.0.96.
- Add release notes for LAN Firewall sub-policy and rule-ordering support.

## Changelog

### Added
- Added `cato_lf_sub_policy` and `cato_bulk_lf_move_rule` resources for managing LAN Firewall sub-policies and parent-scoped policy ordering.

### Changed
- Extended LAN Firewall section, network rule, and firewall rule handling to support sub-policy placement and ordering.

### Fixed
- Hardened LAN policy lifecycle and state hydration for omitted rule maps, imported sub-policy positions, transient reads, and mutation status errors.

### Tests
- Added unit and acceptance coverage for LAN Firewall sub-policy lifecycle, rule ordering, and network and firewall rule behavior.

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] `make vul`