### PR TITLE
fix(acctest): clean stale test resources

### DIFF
--- a/internal/acctests/acc/cleanup_application_policies.go
+++ b/internal/acctests/acc/cleanup_application_policies.go
@@ -1,0 +1,252 @@
+//go:build acctest
+
+package acc
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	cato "github.com/catonetworks/cato-go-sdk"
+	cato_models "github.com/catonetworks/cato-go-sdk/models"
+)
+
+type applicationPolicyCleanupOperations struct {
+	removeRule    cleanupRemoveFunc
+	removeSection cleanupRemoveFunc
+	publish       func() error
+}
+
+func deleteApplicationControlElements(t *testing.T) error {
+	client := GetClient(t)
+	result, err := client.ApplicationControlPolicy(ctx, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("reading Application Control policy: %w", err)
+	}
+	if result == nil {
+		return errors.New("reading Application Control policy: missing response")
+	}
+	if revision := result.GetPolicy().GetApplicationControl().GetPolicy().GetRevision(); revision != nil {
+		if err = validateExistingPolicyRevision("Application Control", revision.GetID(), revision.GetChanges()); err != nil {
+			return err
+		}
+	}
+
+	rules, sections := applicationControlCleanupElements(result)
+	operations := applicationPolicyCleanupOperations{
+		removeRule: func(id string) (cleanupMutationResult, error) {
+			response, removeErr := client.PolicyApplicationControlRemoveRule(
+				ctx,
+				cato_models.ApplicationControlRemoveRuleInput{ID: id},
+				CatoAccountID,
+			)
+			if removeErr != nil {
+				return cleanupMutationResult{}, removeErr
+			}
+			if response == nil {
+				return cleanupMutationResult{}, errors.New("missing mutation response")
+			}
+			payload := response.GetPolicy().GetApplicationControl().GetRemoveRule()
+			payloadErrors := payload.GetErrors()
+			return cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			}, nil
+		},
+		removeSection: func(id string) (cleanupMutationResult, error) {
+			response, removeErr := client.PolicyApplicationControlRemoveSection(
+				ctx,
+				cato_models.PolicyRemoveSectionInput{ID: id},
+				CatoAccountID,
+			)
+			if removeErr != nil {
+				return cleanupMutationResult{}, removeErr
+			}
+			if response == nil {
+				return cleanupMutationResult{}, errors.New("missing mutation response")
+			}
+			payload := response.GetPolicy().GetApplicationControl().GetRemoveSection()
+			payloadErrors := payload.GetErrors()
+			return cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			}, nil
+		},
+		publish: func() error {
+			response, publishErr := client.PolicyApplicationControlPublishPolicyRevision(ctx, CatoAccountID)
+			if publishErr != nil {
+				return fmt.Errorf("publishing Application Control policy revision: %w", publishErr)
+			}
+			if response == nil {
+				return errors.New("publishing Application Control policy revision: missing response")
+			}
+			payload := response.GetPolicy().GetApplicationControl().GetPublishPolicyRevision()
+			payloadErrors := payload.GetErrors()
+			return validateCleanupMutation("publishing Application Control policy revision", cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			})
+		},
+	}
+
+	// Application Control is a singleton policy. Global cleanup cannot restore its
+	// baseline because no pre-test baseline is stored; only owned elements are removed.
+	return runApplicationPolicyCleanup(rules, sections, operations)
+}
+
+func deleteAppTenantRestrictionElements(t *testing.T) error {
+	client := GetClient(t)
+	result, err := client.AppTenantRestrictionPolicy(ctx, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("reading App Tenant Restriction policy: %w", err)
+	}
+	if result == nil {
+		return errors.New("reading App Tenant Restriction policy: missing response")
+	}
+	if revision := result.GetPolicy().GetAppTenantRestriction().GetPolicy().GetRevision(); revision != nil {
+		if err = validateExistingPolicyRevision(
+			"App Tenant Restriction",
+			revision.GetID(),
+			revision.GetChanges(),
+		); err != nil {
+			return err
+		}
+	}
+
+	rules, sections := appTenantRestrictionCleanupElements(result)
+	operations := applicationPolicyCleanupOperations{
+		removeRule: func(id string) (cleanupMutationResult, error) {
+			response, removeErr := client.PolicyAppTenantRestrictionRemoveRule(
+				ctx,
+				cato_models.AppTenantRestrictionRemoveRuleInput{ID: id},
+				CatoAccountID,
+			)
+			if removeErr != nil {
+				return cleanupMutationResult{}, removeErr
+			}
+			if response == nil {
+				return cleanupMutationResult{}, errors.New("missing mutation response")
+			}
+			payload := response.GetPolicy().GetAppTenantRestriction().GetRemoveRule()
+			payloadErrors := payload.GetErrors()
+			return cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			}, nil
+		},
+		removeSection: func(id string) (cleanupMutationResult, error) {
+			response, removeErr := client.PolicyAppTenantRestrictionRemoveSection(
+				ctx,
+				cato_models.PolicyRemoveSectionInput{ID: id},
+				CatoAccountID,
+			)
+			if removeErr != nil {
+				return cleanupMutationResult{}, removeErr
+			}
+			if response == nil {
+				return cleanupMutationResult{}, errors.New("missing mutation response")
+			}
+			payload := response.GetPolicy().GetAppTenantRestriction().GetRemoveSection()
+			payloadErrors := payload.GetErrors()
+			return cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			}, nil
+		},
+		publish: func() error {
+			response, publishErr := client.PolicyAppTenantRestrictionPublishPolicyRevision(ctx, CatoAccountID)
+			if publishErr != nil {
+				return fmt.Errorf("publishing App Tenant Restriction policy revision: %w", publishErr)
+			}
+			if response == nil {
+				return errors.New("publishing App Tenant Restriction policy revision: missing response")
+			}
+			payload := response.GetPolicy().GetAppTenantRestriction().GetPublishPolicyRevision()
+			payloadErrors := payload.GetErrors()
+			return validateCleanupMutation("publishing App Tenant Restriction policy revision", cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			})
+		},
+	}
+
+	return runApplicationPolicyCleanup(rules, sections, operations)
+}
+
+func runApplicationPolicyCleanup(
+	rules []cleanupPolicyElement,
+	sections []cleanupPolicyElement,
+	operations applicationPolicyCleanupOperations,
+) error {
+	rulesChanged, ruleErr := removeCleanupPolicyElements(rules, operations.removeRule)
+	sectionsChanged, sectionErr := removeCleanupPolicyElements(sections, operations.removeSection)
+	cleanupErr := errors.Join(ruleErr, sectionErr)
+	if !rulesChanged && !sectionsChanged {
+		return cleanupErr
+	}
+	return errors.Join(cleanupErr, operations.publish())
+}
+
+func applicationControlCleanupElements(
+	result *cato.ApplicationControlPolicy,
+) (rules []cleanupPolicyElement, sections []cleanupPolicyElement) {
+	policy := result.GetPolicy().GetApplicationControl().GetPolicy()
+	for _, wrapper := range policy.GetRules() {
+		if wrapper == nil || !acctestRE.MatchString(wrapper.GetRule().GetName()) {
+			continue
+		}
+		rule := wrapper.GetRule()
+		rules = append(rules, cleanupPolicyElement{
+			kind: "Application Control rule",
+			name: rule.GetName(),
+			id:   rule.GetID(),
+		})
+	}
+	for _, wrapper := range policy.GetSections() {
+		if wrapper == nil || !acctestRE.MatchString(wrapper.GetSection().GetName()) {
+			continue
+		}
+		section := wrapper.GetSection()
+		sections = append(sections, cleanupPolicyElement{
+			kind: "Application Control section",
+			name: section.GetName(),
+			id:   section.GetID(),
+		})
+	}
+	return rules, sections
+}
+
+func appTenantRestrictionCleanupElements(
+	result *cato.AppTenantRestrictionPolicy,
+) (rules []cleanupPolicyElement, sections []cleanupPolicyElement) {
+	policy := result.GetPolicy().GetAppTenantRestriction().GetPolicy()
+	for _, wrapper := range policy.GetRules() {
+		if wrapper == nil || !acctestRE.MatchString(wrapper.GetRule().GetName()) {
+			continue
+		}
+		rule := wrapper.GetRule()
+		rules = append(rules, cleanupPolicyElement{
+			kind: "App Tenant Restriction rule",
+			name: rule.GetName(),
+			id:   rule.GetID(),
+		})
+	}
+	for _, wrapper := range policy.GetSections() {
+		if wrapper == nil || !acctestRE.MatchString(wrapper.GetSection().GetName()) {
+			continue
+		}
+		section := wrapper.GetSection()
+		sections = append(sections, cleanupPolicyElement{
+			kind: "App Tenant Restriction section",
+			name: section.GetName(),
+			id:   section.GetID(),
+		})
+	}
+	return rules, sections
+}

--- a/internal/acctests/acc/cleanup_entities.go
+++ b/internal/acctests/acc/cleanup_entities.go
@@ -1,0 +1,345 @@
+//go:build acctest
+
+package acc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	cato "github.com/catonetworks/cato-go-sdk"
+	cato_models "github.com/catonetworks/cato-go-sdk/models"
+)
+
+const (
+	envEnableAccountCRUD        = "TFACC_ENABLE_ACCOUNT_CRUD"
+	envEnableAccountCRUDAllowed = "TFACC_ACCOUNT_CRUD_ALLOWED"
+
+	disableAccountDocument = `mutation accountManagementDisableAccount(
+		$accountId: ID!
+		$accountIdToDisable: ID!
+	) {
+		accountManagement(accountId: $accountId) {
+			disableAccount(accountId: $accountIdToDisable) {
+				accountInfo {
+					id
+					status
+				}
+			}
+		}
+	}`
+)
+
+type disableAccountResponse struct {
+	AccountManagement *disableAccountManagement `json:"accountManagement"`
+}
+
+type disableAccountManagement struct {
+	DisableAccount *disableAccountPayload `json:"disableAccount"`
+}
+
+type disableAccountPayload struct {
+	AccountInfo *disabledAccountInfo `json:"accountInfo"`
+}
+
+type disabledAccountInfo struct {
+	ID     string                    `json:"id"`
+	Status cato_models.AccountStatus `json:"status"`
+}
+
+func deleteSitesAndDependencies(t *testing.T) error {
+	client := GetClient(t)
+	sites := selectAcctestRefs(getEntities(t, resSite), "")
+	if !sameIDSet(idsFromRefs(sites), idsFromRefs(sites)) {
+		return errors.New("acctest site lookup returned blank or duplicate IDs")
+	}
+
+	var cleanupErrors []error
+	for _, site := range sites {
+		if err := deleteSiteBGPPeers(client, site); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+
+		result, err := client.SiteRemoveSite(ctx, site.ID, CatoAccountID)
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("deleting site %s (%s): %w", site.Name, site.ID, err))
+			continue
+		}
+		if removedID := result.GetSite().GetRemoveSite().GetSiteID(); removedID != site.ID {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf(
+				"deleting site %s (%s): response ID %q", site.Name, site.ID, removedID,
+			))
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
+}
+
+func deleteSiteBGPPeers(client *cato.Client, site Ref) error {
+	input := cato_models.BgpPeerListInput{
+		Site: &cato_models.SiteRefInput{
+			By:    cato_models.ObjectRefByID,
+			Input: site.ID,
+		},
+	}
+	result, err := client.SiteBgpPeerList(ctx, input, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("listing BGP peers for site %s (%s): %w", site.Name, site.ID, err)
+	}
+	if result == nil || result.GetSite() == nil || result.GetSite().GetBgpPeerList() == nil {
+		return fmt.Errorf("listing BGP peers for site %s (%s): missing response payload", site.Name, site.ID)
+	}
+
+	peerList := result.GetSite().GetBgpPeerList()
+	peers := peerList.GetBgpPeerBgpPeerListPayload()
+	if peerList.GetTotal() != int64(len(peers)) {
+		return fmt.Errorf(
+			"listing BGP peers for site %s (%s): got %d items, total is %d",
+			site.Name, site.ID, len(peers), peerList.GetTotal(),
+		)
+	}
+
+	peerIDs := make([]string, 0, len(peers))
+	var cleanupErrors []error
+	for _, peer := range peers {
+		if peer == nil {
+			continue
+		}
+		if !acctestRE.MatchString(peer.GetName()) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf(
+				"refusing to delete site %s (%s): contains non-acctest BGP peer %s (%s)",
+				site.Name,
+				site.ID,
+				peer.GetName(),
+				peer.GetID(),
+			))
+			continue
+		}
+		peerIDs = append(peerIDs, peer.GetID())
+	}
+	if !sameIDSet(peerIDs, peerIDs) {
+		return fmt.Errorf("listing BGP peers for site %s (%s): blank or duplicate peer IDs", site.Name, site.ID)
+	}
+
+	for _, peerID := range peerIDs {
+		removeInput := cato_models.RemoveBgpPeerInput{ID: peerID}
+		removeResult, removeErr := client.SiteRemoveBgpPeer(ctx, removeInput, CatoAccountID)
+		if removeErr != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf(
+				"deleting BGP peer %s from site %s (%s): %w", peerID, site.Name, site.ID, removeErr,
+			))
+			continue
+		}
+		if removedID := removeResult.GetSite().GetRemoveBgpPeer().GetBgpPeer().GetID(); removedID != peerID {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf(
+				"deleting BGP peer %s from site %s (%s): response ID %q",
+				peerID, site.Name, site.ID, removedID,
+			))
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
+}
+
+func deleteAcctestGlobalIPRanges(t *testing.T) error {
+	client := GetClient(t)
+	result, err := client.ObjectGlobalIPRangeList(ctx, CatoAccountID, nil)
+	if err != nil {
+		return fmt.Errorf("listing global IP ranges: %w", err)
+	}
+	refs, err := globalIPRangeRefs(result)
+	if err != nil {
+		return err
+	}
+	return deleteGlobalIPRangeRefs(client, selectAcctestRefs(refs, ""))
+}
+
+func globalIPRangeRefs(result *cato.ObjectGlobalIPRangeList) ([]Ref, error) {
+	if result == nil || result.GetObject() == nil || result.GetObject().GetGlobalIPRangeList() == nil {
+		return nil, errors.New("listing global IP ranges: missing response payload")
+	}
+
+	rangeList := result.GetObject().GetGlobalIPRangeList()
+	items := rangeList.GetItems()
+	if rangeList.GetTotal() != int64(len(items)) {
+		return nil, fmt.Errorf("listing global IP ranges: got %d items, total is %d", len(items), rangeList.GetTotal())
+	}
+
+	refs := make([]Ref, 0, len(items))
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		refs = append(refs, Ref{ID: item.GetID(), Name: item.GetName()})
+	}
+	return refs, nil
+}
+
+func deleteGlobalIPRangeRefs(client *cato.Client, refs []Ref) error {
+	expectedIDs := idsFromRefs(refs)
+	if !sameIDSet(expectedIDs, expectedIDs) {
+		return errors.New("acctest global IP range lookup returned duplicate IDs")
+	}
+	if len(expectedIDs) == 0 {
+		return nil
+	}
+
+	input := make([]*cato_models.GlobalIPRangeRefInput, 0, len(expectedIDs))
+	for _, id := range expectedIDs {
+		input = append(input, &cato_models.GlobalIPRangeRefInput{
+			By:    cato_models.ObjectRefByID,
+			Input: id,
+		})
+	}
+	removeResult, err := client.ObjectDeleteGlobalIPRangeBulk(ctx, CatoAccountID, input)
+	if err != nil {
+		return fmt.Errorf("deleting acctest global IP ranges: %w", err)
+	}
+	if removeResult == nil ||
+		removeResult.GetObject() == nil ||
+		removeResult.GetObject().GetDeleteGlobalIPRangeBulk() == nil {
+		return errors.New("deleting acctest global IP ranges: missing response payload")
+	}
+
+	removed := removeResult.GetObject().GetDeleteGlobalIPRangeBulk().GetGlobalIPRange()
+	removedIDs := make([]string, 0, len(removed))
+	for _, item := range removed {
+		removedIDs = append(removedIDs, item.GetID())
+	}
+	if !sameIDSet(expectedIDs, removedIDs) {
+		return fmt.Errorf(
+			"deleting acctest global IP ranges: returned IDs %v, expected %v",
+			removedIDs, expectedIDs,
+		)
+	}
+
+	return nil
+}
+
+func deleteAcctestAccounts(t *testing.T) error {
+	if os.Getenv(envEnableAccountCRUD) != "true" || os.Getenv(envEnableAccountCRUDAllowed) != "true" {
+		return nil
+	}
+
+	client := GetClient(t)
+	accounts := selectAcctestRefs(getEntities(t, resAccount), CatoAccountID)
+	accountIDs := idsFromRefs(accounts)
+	if !sameIDSet(accountIDs, accountIDs) {
+		return errors.New("acctest subaccount lookup returned duplicate IDs")
+	}
+
+	var cleanupErrors []error
+	for _, account := range accounts {
+		if err := disableAcctestAccount(client, account); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+
+		removeResult, removeErr := client.AccountManagementRemoveAccount(ctx, account.ID, CatoAccountID)
+		if removeErr != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf(
+				"removing subaccount %s (%s): %w", account.Name, account.ID, removeErr,
+			))
+			continue
+		}
+		removedID := removeResult.GetAccountManagement().GetRemoveAccount().GetAccountInfo().GetID()
+		if removedID != account.ID {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf(
+				"removing subaccount %s (%s): response ID %q", account.Name, account.ID, removedID,
+			))
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
+}
+
+func disableAcctestAccount(client *cato.Client, account Ref) error {
+	var result disableAccountResponse
+	variables := map[string]any{
+		"accountId":          CatoAccountID,
+		"accountIdToDisable": account.ID,
+	}
+	if err := client.Client.Post(
+		ctx,
+		"accountManagementDisableAccount",
+		disableAccountDocument,
+		&result,
+		variables,
+	); err != nil {
+		return fmt.Errorf("disabling subaccount %s (%s): %w", account.Name, account.ID, err)
+	}
+	if result.AccountManagement == nil ||
+		result.AccountManagement.DisableAccount == nil ||
+		result.AccountManagement.DisableAccount.AccountInfo == nil {
+		return fmt.Errorf("disabling subaccount %s (%s): missing response payload", account.Name, account.ID)
+	}
+
+	accountInfo := result.AccountManagement.DisableAccount.AccountInfo
+	if accountInfo.ID != account.ID {
+		return fmt.Errorf(
+			"disabling subaccount %s (%s): response ID %q", account.Name, account.ID, accountInfo.ID,
+		)
+	}
+	if accountInfo.Status != cato_models.AccountStatusDisabled {
+		return fmt.Errorf(
+			"disabling subaccount %s (%s): response status %q",
+			account.Name, account.ID, accountInfo.Status,
+		)
+	}
+
+	return nil
+}
+
+func selectAcctestRefs(refs []Ref, excludedID string) []Ref {
+	selected := make([]Ref, 0, len(refs))
+	for _, ref := range refs {
+		if ref.ID == "" || ref.ID == excludedID || !acctestRE.MatchString(ref.Name) {
+			continue
+		}
+		selected = append(selected, ref)
+	}
+	return selected
+}
+
+func idsFromRefs(refs []Ref) []string {
+	ids := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, ref.ID)
+	}
+	return ids
+}
+
+func sameIDSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	leftSet := make(map[string]struct{}, len(left))
+	for _, id := range left {
+		if id == "" {
+			return false
+		}
+		if _, duplicate := leftSet[id]; duplicate {
+			return false
+		}
+		leftSet[id] = struct{}{}
+	}
+
+	rightSet := make(map[string]struct{}, len(right))
+	for _, id := range right {
+		if id == "" {
+			return false
+		}
+		if _, duplicate := rightSet[id]; duplicate {
+			return false
+		}
+		if _, expected := leftSet[id]; !expected {
+			return false
+		}
+		rightSet[id] = struct{}{}
+	}
+
+	return true
+}

--- a/internal/acctests/acc/cleanup_entities_test.go
+++ b/internal/acctests/acc/cleanup_entities_test.go
@@ -1,0 +1,52 @@
+//go:build acctest
+
+package acc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSelectAcctestRefs(t *testing.T) {
+	t.Parallel()
+
+	refs := []Ref{
+		{ID: "1", Name: "acctest_site"},
+		{ID: "2", Name: "production_site"},
+		{ID: "", Name: "acctest_missing_id"},
+		{ID: "root", Name: "acctest_root"},
+	}
+	got := selectAcctestRefs(refs, "root")
+	want := []Ref{{ID: "1", Name: "acctest_site"}}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selectAcctestRefs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSameIDSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		left  []string
+		right []string
+		want  bool
+	}{
+		{name: "same unordered IDs", left: []string{"1", "2"}, right: []string{"2", "1"}, want: true},
+		{name: "different IDs", left: []string{"1", "2"}, right: []string{"1", "3"}},
+		{name: "different lengths", left: []string{"1"}, right: []string{"1", "2"}},
+		{name: "blank ID", left: []string{""}, right: []string{""}},
+		{name: "duplicate expected ID", left: []string{"1", "1"}, right: []string{"1", "1"}},
+		{name: "duplicate returned ID", left: []string{"1", "2"}, right: []string{"1", "1"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sameIDSet(test.left, test.right); got != test.want {
+				t.Fatalf("sameIDSet(%v, %v) = %t, want %t", test.left, test.right, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/acctests/acc/cleanup_firewall_policies.go
+++ b/internal/acctests/acc/cleanup_firewall_policies.go
@@ -1,0 +1,410 @@
+//go:build acctest
+
+package acc
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	cato "github.com/catonetworks/cato-go-sdk"
+	cato_models "github.com/catonetworks/cato-go-sdk/models"
+)
+
+type firewallCleanupElement struct {
+	name string
+	id   string
+}
+
+type firewallCleanupPlan struct {
+	rules       []firewallCleanupElement
+	sections    []firewallCleanupElement
+	subPolicies []firewallCleanupElement
+	blocked     []error
+}
+
+type firewallCleanupOperations struct {
+	deleteRule      func(firewallCleanupElement) (bool, error)
+	deleteSection   func(firewallCleanupElement) (bool, error)
+	deleteSubPolicy func(firewallCleanupElement) (bool, error)
+	publish         func() error
+}
+
+type firewallPayloadError interface {
+	GetErrorCode() *string
+	GetErrorMessage() *string
+}
+
+func deleteInternetFirewallElements(t *testing.T) error {
+	client := GetClient(t)
+	result, err := client.PolicyInternetFirewall(ctx, &cato_models.InternetFirewallPolicyInput{}, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("reading Internet Firewall policy: %w", err)
+	}
+	if revision := result.GetPolicy().GetInternetFirewall().GetPolicy().GetRevision(); revision != nil {
+		if err = validateExistingPolicyRevision("Internet Firewall", revision.GetID(), revision.GetChanges()); err != nil {
+			return err
+		}
+	}
+
+	operations := firewallCleanupOperations{
+		deleteRule: func(element firewallCleanupElement) (bool, error) {
+			input := cato_models.InternetFirewallRemoveRuleInput{ID: element.id}
+			response, callErr := client.PolicyInternetFirewallRemoveRule(
+				ctx,
+				&cato_models.InternetFirewallPolicyMutationInput{},
+				input,
+				CatoAccountID,
+			)
+			action := fmt.Sprintf("deleting Internet Firewall rule %s (%s)", element.name, element.id)
+			if response == nil {
+				return false, missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetInternetFirewall().GetRemoveRule()
+			return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+		},
+		deleteSection: func(element firewallCleanupElement) (bool, error) {
+			input := cato_models.PolicyRemoveSectionInput{ID: element.id}
+			response, callErr := client.PolicyInternetFirewallRemoveSection(
+				ctx,
+				&cato_models.InternetFirewallPolicyMutationInput{},
+				input,
+				CatoAccountID,
+			)
+			action := fmt.Sprintf("deleting Internet Firewall section %s (%s)", element.name, element.id)
+			if response == nil {
+				return false, missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetInternetFirewall().GetRemoveSection()
+			return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+		},
+		deleteSubPolicy: func(element firewallCleanupElement) (bool, error) {
+			input := cato_models.InternetFirewallRemoveSubPolicyInput{
+				Ref: &cato_models.InternetFirewallPolicyRefInput{
+					By:    cato_models.ObjectRefByID,
+					Input: element.id,
+				},
+			}
+			response, callErr := client.PolicyInternetFirewallRemoveSubPolicy(
+				ctx,
+				&cato_models.InternetFirewallPolicyMutationInput{},
+				input,
+				CatoAccountID,
+			)
+			action := fmt.Sprintf("deleting Internet Firewall sub-policy %s (%s)", element.name, element.id)
+			if response == nil {
+				return false, missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetInternetFirewall().GetRemoveSubPolicy()
+			return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+		},
+		publish: func() error {
+			response, callErr := client.PolicyInternetFirewallPublishPolicyRevision(
+				ctx,
+				&cato_models.InternetFirewallPolicyMutationInput{},
+				&cato_models.PolicyPublishRevisionInput{},
+				CatoAccountID,
+			)
+			const action = "publishing Internet Firewall policy revision"
+			if response == nil {
+				return missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetInternetFirewall().GetPublishPolicyRevision()
+			_, publishErr := firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+			return publishErr
+		},
+	}
+
+	return runFirewallCleanup(internetFirewallCleanupPlan(result), operations)
+}
+
+func deleteWanFirewallElements(t *testing.T) error {
+	client := GetClient(t)
+	result, err := client.PolicyWanFirewall(ctx, &cato_models.WanFirewallPolicyInput{}, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("reading WAN Firewall policy: %w", err)
+	}
+	if revision := result.GetPolicy().GetWanFirewall().GetPolicy().GetRevision(); revision != nil {
+		if err = validateExistingPolicyRevision("WAN Firewall", revision.GetID(), revision.GetChanges()); err != nil {
+			return err
+		}
+	}
+
+	operations := firewallCleanupOperations{
+		deleteRule: func(element firewallCleanupElement) (bool, error) {
+			input := cato_models.WanFirewallRemoveRuleInput{ID: element.id}
+			response, callErr := client.PolicyWanFirewallRemoveRule(ctx, input, CatoAccountID)
+			action := fmt.Sprintf("deleting WAN Firewall rule %s (%s)", element.name, element.id)
+			if response == nil {
+				return false, missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetWanFirewall().GetRemoveRule()
+			return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+		},
+		deleteSection: func(element firewallCleanupElement) (bool, error) {
+			input := cato_models.PolicyRemoveSectionInput{ID: element.id}
+			response, callErr := client.PolicyWanFirewallRemoveSection(ctx, input, CatoAccountID)
+			action := fmt.Sprintf("deleting WAN Firewall section %s (%s)", element.name, element.id)
+			if response == nil {
+				return false, missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetWanFirewall().GetRemoveSection()
+			return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+		},
+		deleteSubPolicy: func(element firewallCleanupElement) (bool, error) {
+			input := cato_models.WanFirewallRemoveSubPolicyInput{
+				Ref: &cato_models.WanFirewallPolicyRefInput{
+					By:    cato_models.ObjectRefByID,
+					Input: element.id,
+				},
+			}
+			response, callErr := client.PolicyWanFirewallRemoveSubPolicy(ctx, input, CatoAccountID)
+			action := fmt.Sprintf("deleting WAN Firewall sub-policy %s (%s)", element.name, element.id)
+			if response == nil {
+				return false, missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetWanFirewall().GetRemoveSubPolicy()
+			return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+		},
+		publish: func() error {
+			response, callErr := client.PolicyWanFirewallPublishPolicyRevision(
+				ctx,
+				&cato_models.PolicyPublishRevisionInput{},
+				CatoAccountID,
+			)
+			const action = "publishing WAN Firewall policy revision"
+			if response == nil {
+				return missingFirewallMutationResponse(action, callErr)
+			}
+			payload := response.GetPolicy().GetWanFirewall().GetPublishPolicyRevision()
+			_, publishErr := firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+			return publishErr
+		},
+	}
+
+	return runFirewallCleanup(wanFirewallCleanupPlan(result), operations)
+}
+
+func runFirewallCleanup(plan firewallCleanupPlan, operations firewallCleanupOperations) error {
+	rulesChanged, ruleErr := deleteFirewallCleanupElements(plan.rules, operations.deleteRule)
+	sectionsChanged, sectionErr := deleteFirewallCleanupElements(plan.sections, operations.deleteSection)
+	subPoliciesChanged, subPolicyErr := deleteFirewallCleanupElements(plan.subPolicies, operations.deleteSubPolicy)
+
+	deleteErr := errors.Join(errors.Join(plan.blocked...), ruleErr, sectionErr, subPolicyErr)
+	if !rulesChanged && !sectionsChanged && !subPoliciesChanged {
+		return deleteErr
+	}
+
+	return errors.Join(deleteErr, operations.publish())
+}
+
+func deleteFirewallCleanupElements(
+	elements []firewallCleanupElement,
+	deleteElement func(firewallCleanupElement) (bool, error),
+) (bool, error) {
+	changed := false
+	var deleteErrs []error
+	for _, element := range elements {
+		elementChanged, err := deleteElement(element)
+		if elementChanged {
+			changed = true
+		}
+		if err != nil {
+			deleteErrs = append(deleteErrs, err)
+		}
+	}
+
+	return changed, errors.Join(deleteErrs...)
+}
+
+func internetFirewallCleanupPlan(result *cato.Policy) firewallCleanupPlan {
+	policy := result.GetPolicy().GetInternetFirewall().GetPolicy()
+	plan := firewallCleanupPlan{}
+	unownedSubPolicies := make(map[string]string)
+
+	for _, wrapper := range policy.GetRules() {
+		if wrapper == nil || *wrapper.GetRuleType() != cato_models.PolicyRuleTypeEnumPolicyRule {
+			continue
+		}
+		if !isFirewallCleanupCandidate(wrapper.GetRule().GetName(), wrapper.GetProperties()) {
+			if subPolicy := wrapper.GetSubPolicy(); subPolicy != nil && subPolicy.GetID() != "" {
+				unownedSubPolicies[subPolicy.GetID()] = wrapper.GetRule().GetName()
+			}
+			continue
+		}
+		plan.rules = append(plan.rules, firewallCleanupElement{
+			name: wrapper.GetRule().GetName(),
+			id:   wrapper.GetRule().GetID(),
+		})
+	}
+	for _, wrapper := range policy.GetSections() {
+		if wrapper == nil ||
+			!isFirewallCleanupCandidate(wrapper.GetSection().GetName(), wrapper.GetProperties()) {
+			continue
+		}
+		plan.sections = append(plan.sections, firewallCleanupElement{
+			name: wrapper.GetSection().GetName(),
+			id:   wrapper.GetSection().GetID(),
+		})
+	}
+	for _, wrapper := range policy.GetSubPolicies() {
+		if wrapper == nil ||
+			!acctestRE.MatchString(wrapper.GetPolicy().GetName()) ||
+			isReadOnlySubPolicy(wrapper.GetProperties()) {
+			continue
+		}
+		if childName, blocked := unownedSubPolicies[wrapper.GetPolicy().GetID()]; blocked {
+			plan.blocked = append(plan.blocked, fmt.Errorf(
+				"refusing to delete Internet Firewall sub-policy %s (%s): contains non-acctest rule %s",
+				wrapper.GetPolicy().GetName(),
+				wrapper.GetPolicy().GetID(),
+				childName,
+			))
+			continue
+		}
+		plan.subPolicies = append(plan.subPolicies, firewallCleanupElement{
+			name: wrapper.GetPolicy().GetName(),
+			id:   wrapper.GetPolicy().GetID(),
+		})
+	}
+
+	return plan
+}
+
+func wanFirewallCleanupPlan(result *cato.Policy) firewallCleanupPlan {
+	policy := result.GetPolicy().GetWanFirewall().GetPolicy()
+	plan := firewallCleanupPlan{}
+	unownedSubPolicies := make(map[string]string)
+
+	for _, wrapper := range policy.GetRules() {
+		if wrapper == nil || *wrapper.GetRuleType() != cato_models.PolicyRuleTypeEnumPolicyRule {
+			continue
+		}
+		if !isFirewallCleanupCandidate(wrapper.GetRule().GetName(), wrapper.GetProperties()) {
+			if subPolicy := wrapper.GetSubPolicy(); subPolicy != nil && subPolicy.GetID() != "" {
+				unownedSubPolicies[subPolicy.GetID()] = wrapper.GetRule().GetName()
+			}
+			continue
+		}
+		plan.rules = append(plan.rules, firewallCleanupElement{
+			name: wrapper.GetRule().GetName(),
+			id:   wrapper.GetRule().GetID(),
+		})
+	}
+	for _, wrapper := range policy.GetSections() {
+		if wrapper == nil ||
+			!isFirewallCleanupCandidate(wrapper.GetSection().GetName(), wrapper.GetProperties()) {
+			continue
+		}
+		plan.sections = append(plan.sections, firewallCleanupElement{
+			name: wrapper.GetSection().GetName(),
+			id:   wrapper.GetSection().GetID(),
+		})
+	}
+	for _, wrapper := range policy.GetSubPolicies() {
+		if wrapper == nil ||
+			!acctestRE.MatchString(wrapper.GetPolicy().GetName()) ||
+			isReadOnlySubPolicy(wrapper.GetProperties()) {
+			continue
+		}
+		if childName, blocked := unownedSubPolicies[wrapper.GetPolicy().GetID()]; blocked {
+			plan.blocked = append(plan.blocked, fmt.Errorf(
+				"refusing to delete WAN Firewall sub-policy %s (%s): contains non-acctest rule %s",
+				wrapper.GetPolicy().GetName(),
+				wrapper.GetPolicy().GetID(),
+				childName,
+			))
+			continue
+		}
+		plan.subPolicies = append(plan.subPolicies, firewallCleanupElement{
+			name: wrapper.GetPolicy().GetName(),
+			id:   wrapper.GetPolicy().GetID(),
+		})
+	}
+
+	return plan
+}
+
+func isFirewallCleanupCandidate(name string, properties []cato_models.PolicyElementPropertiesEnum) bool {
+	if !acctestRE.MatchString(name) {
+		return false
+	}
+	for _, property := range properties {
+		if property == cato_models.PolicyElementPropertiesEnumSystem {
+			return false
+		}
+	}
+	return true
+}
+
+func isReadOnlySubPolicy(properties []cato_models.SubPolicyProperty) bool {
+	for _, property := range properties {
+		if property == cato_models.SubPolicyPropertyReadOnly {
+			return true
+		}
+	}
+	return false
+}
+
+func firewallMutationResult[T firewallPayloadError](
+	action string,
+	callErr error,
+	status *cato_models.PolicyMutationStatus,
+	payloadErrors []T,
+) (bool, error) {
+	var result []error
+	if callErr != nil {
+		result = append(result, fmt.Errorf("%s: %w", action, callErr))
+	}
+	succeeded := status != nil && *status == cato_models.PolicyMutationStatusSuccess
+	if !succeeded {
+		result = append(result, fmt.Errorf("%s: mutation status %s", action, firewallMutationStatus(status)))
+	}
+	for _, payloadErr := range payloadErrors {
+		result = append(result, fmt.Errorf(
+			"%s: API error %s: %s",
+			action,
+			valueOrUnknown(payloadErr.GetErrorCode()),
+			valueOrUnknown(payloadErr.GetErrorMessage()),
+		))
+	}
+	return succeeded, errors.Join(result...)
+}
+
+func missingFirewallMutationResponse(action string, callErr error) error {
+	return errors.Join(
+		func() error {
+			if callErr == nil {
+				return nil
+			}
+			return fmt.Errorf("%s: %w", action, callErr)
+		}(),
+		fmt.Errorf("%s: missing mutation response", action),
+	)
+}
+
+func firewallMutationStatus(status *cato_models.PolicyMutationStatus) string {
+	if status == nil {
+		return "<nil>"
+	}
+	return string(*status)
+}
+
+func valueOrUnknown(value *string) string {
+	if value == nil || *value == "" {
+		return "<unknown>"
+	}
+	return *value
+}
+
+func validateExistingPolicyRevision(policyName, revisionID string, changes int64) error {
+	if changes == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s policy has existing draft revision %q with %d changes; refusing to publish or discard unowned changes",
+		policyName,
+		revisionID,
+		changes,
+	)
+}

--- a/internal/acctests/acc/cleanup_firewall_policies_test.go
+++ b/internal/acctests/acc/cleanup_firewall_policies_test.go
@@ -1,0 +1,204 @@
+//go:build acctest
+
+package acc
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	cato "github.com/catonetworks/cato-go-sdk"
+	cato_models "github.com/catonetworks/cato-go-sdk/models"
+)
+
+type testFirewallPayloadError struct {
+	code    *string
+	message *string
+}
+
+func (e *testFirewallPayloadError) GetErrorCode() *string {
+	return e.code
+}
+
+func (e *testFirewallPayloadError) GetErrorMessage() *string {
+	return e.message
+}
+
+func TestRunFirewallCleanupPublishesAfterPartialSuccess(t *testing.T) {
+	deleteErr := errors.New("delete failed")
+	var calls []string
+	plan := firewallCleanupPlan{
+		rules:       []firewallCleanupElement{{name: "rule"}},
+		sections:    []firewallCleanupElement{{name: "section"}},
+		subPolicies: []firewallCleanupElement{{name: "sub-policy"}},
+	}
+	operations := firewallCleanupOperations{
+		deleteRule: func(element firewallCleanupElement) (bool, error) {
+			calls = append(calls, "rule:"+element.name)
+			return false, deleteErr
+		},
+		deleteSection: func(element firewallCleanupElement) (bool, error) {
+			calls = append(calls, "section:"+element.name)
+			return true, nil
+		},
+		deleteSubPolicy: func(element firewallCleanupElement) (bool, error) {
+			calls = append(calls, "sub-policy:"+element.name)
+			return true, nil
+		},
+		publish: func() error {
+			calls = append(calls, "publish")
+			return nil
+		},
+	}
+
+	err := runFirewallCleanup(plan, operations)
+
+	if !errors.Is(err, deleteErr) {
+		t.Fatalf("runFirewallCleanup() error = %v, want joined delete error", err)
+	}
+	wantCalls := []string{"rule:rule", "section:section", "sub-policy:sub-policy", "publish"}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %v, want %v", calls, wantCalls)
+	}
+}
+
+func TestRunFirewallCleanupDoesNotPublishWithoutSuccessfulMutation(t *testing.T) {
+	deleteErr := errors.New("delete failed")
+	published := false
+	plan := firewallCleanupPlan{
+		rules: []firewallCleanupElement{{name: "rule"}},
+	}
+	operations := firewallCleanupOperations{
+		deleteRule: func(firewallCleanupElement) (bool, error) { return false, deleteErr },
+		deleteSection: func(firewallCleanupElement) (bool, error) {
+			t.Fatal("unexpected section deletion")
+			return false, nil
+		},
+		deleteSubPolicy: func(firewallCleanupElement) (bool, error) {
+			t.Fatal("unexpected sub-policy deletion")
+			return false, nil
+		},
+		publish: func() error {
+			published = true
+			return nil
+		},
+	}
+
+	err := runFirewallCleanup(plan, operations)
+
+	if !errors.Is(err, deleteErr) {
+		t.Fatalf("runFirewallCleanup() error = %v, want delete error", err)
+	}
+	if published {
+		t.Fatal("runFirewallCleanup() published without a successful mutation")
+	}
+}
+
+func TestIsFirewallCleanupCandidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		element    string
+		properties []cato_models.PolicyElementPropertiesEnum
+		want       bool
+	}{
+		{name: "matching user element", element: "acctest_rule", want: true},
+		{name: "different prefix", element: "production_rule", want: false},
+		{
+			name:       "system element",
+			element:    "acctest_system_rule",
+			properties: []cato_models.PolicyElementPropertiesEnum{cato_models.PolicyElementPropertiesEnumSystem},
+			want:       false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isFirewallCleanupCandidate(test.element, test.properties); got != test.want {
+				t.Fatalf("isFirewallCleanupCandidate() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFirewallMutationResultIncludesStatusAndPayloadErrors(t *testing.T) {
+	status := cato_models.PolicyMutationStatusFailure
+	code := "INVALID"
+	message := "cannot delete"
+
+	changed, err := firewallMutationResult(
+		"deleting rule",
+		nil,
+		&status,
+		[]*testFirewallPayloadError{{code: &code, message: &message}},
+	)
+
+	if changed {
+		t.Fatal("firewallMutationResult() changed = true for failed status")
+	}
+	if err == nil {
+		t.Fatal("firewallMutationResult() error = nil")
+	}
+	for _, want := range []string{"mutation status FAILURE", "API error INVALID: cannot delete"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("firewallMutationResult() error = %q, want substring %q", err, want)
+		}
+	}
+}
+
+func TestRunApplicationPolicyCleanupOrdersDeletesAndPublishes(t *testing.T) {
+	var calls []string
+	operations := applicationPolicyCleanupOperations{
+		removeRule: func(id string) (cleanupMutationResult, error) {
+			calls = append(calls, "rule:"+id)
+			return successfulCleanupMutation(), nil
+		},
+		removeSection: func(id string) (cleanupMutationResult, error) {
+			calls = append(calls, "section:"+id)
+			return successfulCleanupMutation(), nil
+		},
+		publish: func() error {
+			calls = append(calls, "publish")
+			return nil
+		},
+	}
+
+	err := runApplicationPolicyCleanup(
+		[]cleanupPolicyElement{{id: "rule-id"}},
+		[]cleanupPolicyElement{{id: "section-id"}},
+		operations,
+	)
+	if err != nil {
+		t.Fatalf("runApplicationPolicyCleanup() error = %v", err)
+	}
+	want := []string{"rule:rule-id", "section:section-id", "publish"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestHasUnownedSocketLanFirewallRules(t *testing.T) {
+	firewallRule := func(name string) *cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule_Firewall {
+		return &cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule_Firewall{
+			Rule: cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule_Firewall_Rule{
+				Name: name,
+			},
+		}
+	}
+
+	if hasUnownedSocketLanFirewallRules([]*cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule_Firewall{
+		firewallRule("acctest_child"),
+	}) {
+		t.Fatal("owned firewall rule reported as unowned")
+	}
+	if !hasUnownedSocketLanFirewallRules([]*cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule_Firewall{
+		firewallRule("production_child"),
+	}) {
+		t.Fatal("unowned firewall rule not detected")
+	}
+}
+
+func successfulCleanupMutation() cleanupMutationResult {
+	status := cato_models.PolicyMutationStatusSuccess
+	return cleanupMutationResult{status: &status}
+}

--- a/internal/acctests/acc/cleanup_test.go
+++ b/internal/acctests/acc/cleanup_test.go
@@ -3,55 +3,286 @@
 package acc
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"testing"
 
+	cato "github.com/catonetworks/cato-go-sdk"
 	cato_models "github.com/catonetworks/cato-go-sdk/models"
 )
-
-var acctestRE = regexp.MustCompile(`^acctest_`)
 
 func TestCleanupAccTestResources(t *testing.T) {
 	if os.Getenv("ACCTEST_CLEANUP") != "true" {
 		t.Log("Skipping cleanup of test resources. Set ACCTEST_CLEANUP=true to enable.")
 		return
 	}
-	var errors []error
-	var helpers = []func(t *testing.T) error{
-		deletePrivateAccessRules,
-		deleteSites,
-	}
+	var cleanupErrors []error
 
 	GetClient(t)
 
-	run := func(helper func(t *testing.T) error) {
+	run := func(helper func(t *testing.T) error) bool {
 		if err := helper(t); err != nil {
-			errors = append(errors, err)
+			cleanupErrors = append(cleanupErrors, err)
+			return false
+		}
+		return true
+	}
+
+	policyClean := true
+	for _, helper := range []func(t *testing.T) error{
+		deletePrivateAccessRules,
+		deleteInternetFirewallElements,
+		deleteWanFirewallElements,
+		deleteSocketLanRules,
+		deleteTLSInspectionElements,
+		deleteWanNetworkElements,
+		deleteApplicationControlElements,
+		deleteAppTenantRestrictionElements,
+	} {
+		if !run(helper) {
+			policyClean = false
 		}
 	}
 
-	for _, helper := range helpers {
-		run(helper)
+	if policyClean {
+		run(deleteSitesAndDependencies)
+		run(deleteAcctestGlobalIPRanges)
 	}
+	run(deleteAcctestAccounts)
 
-	if len(errors) > 0 {
-		t.Fatalf("cleanup errors: %v", errors)
+	if len(cleanupErrors) > 0 {
+		t.Fatalf("cleanup errors: %v", cleanupErrors)
 	}
 }
 
-func deleteSites(t *testing.T) error {
-	sites := getEntities(t, resSite)
-	for _, site := range sites {
-		if acctestRE.MatchString(site.Name) {
-			if _, err := catoClient.SiteRemoveSite(ctx, site.ID, CatoAccountID); err != nil {
-				return fmt.Errorf("deleting site %s (%s): %v", site.Name, site.ID, err)
-			}
+func deleteSocketLanRules(t *testing.T) error {
+	client := GetClient(t)
+	result, err := client.PolicySocketLanPolicy(ctx, CatoAccountID, nil)
+	if err != nil {
+		return fmt.Errorf("reading Socket LAN policy: %v", err)
+	}
+
+	policy := result.GetPolicy().GetSocketLan().GetPolicy()
+	if revision := policy.GetRevision(); revision != nil {
+		if err = validateExistingPolicyRevision("Socket LAN", revision.GetID(), revision.GetChanges()); err != nil {
+			return err
 		}
 	}
-	return nil
+	rulesChanged, ruleErr := cleanupSocketLanRules(client, policy.GetRules())
+	sectionsChanged, sectionErr := cleanupSocketLanSections(client, policy.GetSections())
+	subPoliciesChanged, subPolicyErr := cleanupSocketLanSubPolicies(client, policy.GetSubPolicies())
+	cleanupErr := errors.Join(ruleErr, sectionErr, subPolicyErr)
+	if !rulesChanged && !sectionsChanged && !subPoliciesChanged {
+		return cleanupErr
+	}
+
+	return errors.Join(cleanupErr, publishSocketLanPolicy(client))
+}
+
+func cleanupSocketLanRules(
+	client *cato.Client,
+	rules []*cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules,
+) (bool, error) {
+	changed := false
+	var cleanupErr error
+	for _, ruleWrapper := range rules {
+		if ruleWrapper == nil || *ruleWrapper.GetRuleType() != cato_models.PolicyRuleTypeEnumPolicyRule {
+			continue
+		}
+
+		rule := ruleWrapper.GetRule()
+		deleteParent := acctestRE.MatchString(rule.GetName())
+		firewallChanged, deleteErr := deleteSocketLanFirewallRules(client, rule.GetFirewall())
+		if deleteErr != nil {
+			cleanupErr = errors.Join(cleanupErr, deleteErr)
+		}
+		if firewallChanged {
+			changed = true
+		}
+
+		if !deleteParent {
+			continue
+		}
+		if hasUnownedSocketLanFirewallRules(rule.GetFirewall()) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf(
+				"refusing to delete Socket LAN network rule %s (%s): contains non-acctest firewall rules",
+				rule.GetName(),
+				rule.GetID(),
+			))
+			continue
+		}
+		if deleteErr != nil {
+			continue
+		}
+
+		if deleteErr = deleteSocketLanNetworkRule(client, rule); deleteErr != nil {
+			cleanupErr = errors.Join(cleanupErr, deleteErr)
+			continue
+		}
+		changed = true
+	}
+	return changed, cleanupErr
+}
+
+func cleanupSocketLanSections(
+	client *cato.Client,
+	sections []*cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Sections,
+) (bool, error) {
+	changed := false
+	var cleanupErr error
+	for _, wrapper := range sections {
+		if wrapper == nil || !isFirewallCleanupCandidate(
+			wrapper.GetSection().GetName(),
+			wrapper.GetProperties(),
+		) {
+			continue
+		}
+		sectionChanged, deleteErr := deleteSocketLanSection(client, wrapper.GetSection())
+		if deleteErr != nil {
+			cleanupErr = errors.Join(cleanupErr, deleteErr)
+		}
+		if sectionChanged {
+			changed = true
+		}
+	}
+	return changed, cleanupErr
+}
+
+func cleanupSocketLanSubPolicies(
+	client *cato.Client,
+	subPolicies []*cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_SubPolicies,
+) (bool, error) {
+	changed := false
+	var cleanupErr error
+	for _, wrapper := range subPolicies {
+		if wrapper == nil ||
+			!acctestRE.MatchString(wrapper.GetPolicy().GetName()) ||
+			isReadOnlySubPolicy(wrapper.GetProperties()) {
+			continue
+		}
+		subPolicyChanged, deleteErr := deleteSocketLanSubPolicy(client, wrapper.GetPolicy())
+		if deleteErr != nil {
+			cleanupErr = errors.Join(cleanupErr, deleteErr)
+		}
+		if subPolicyChanged {
+			changed = true
+		}
+	}
+	return changed, cleanupErr
+}
+
+func deleteSocketLanFirewallRules(
+	client *cato.Client,
+	firewallRules []*cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule_Firewall,
+) (bool, error) {
+	changed := false
+	for _, firewallWrapper := range firewallRules {
+		if firewallWrapper == nil {
+			continue
+		}
+
+		firewallRule := firewallWrapper.GetRule()
+		if !acctestRE.MatchString(firewallRule.GetName()) {
+			continue
+		}
+
+		input := cato_models.SocketLanFirewallRemoveRuleInput{ID: firewallRule.GetID()}
+		result, callErr := client.PolicySocketLanFirewallRemoveRule(ctx, CatoAccountID, nil, input)
+		action := fmt.Sprintf(
+			"deleting Socket LAN firewall rule %s (%s)",
+			firewallRule.GetName(),
+			firewallRule.GetID(),
+		)
+		if result == nil {
+			return changed, missingFirewallMutationResponse(action, callErr)
+		}
+		payload := result.GetPolicy().GetSocketLan().GetFirewall().GetRemoveRule()
+		succeeded, mutationErr := firewallMutationResult(
+			action,
+			callErr,
+			payload.GetStatus(),
+			payload.GetErrors(),
+		)
+		if mutationErr != nil {
+			return changed, mutationErr
+		}
+		changed = changed || succeeded
+	}
+
+	return changed, nil
+}
+
+func hasUnownedSocketLanFirewallRules(
+	firewallRules []*cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule_Firewall,
+) bool {
+	for _, wrapper := range firewallRules {
+		if wrapper != nil && !acctestRE.MatchString(wrapper.GetRule().GetName()) {
+			return true
+		}
+	}
+	return false
+}
+
+func deleteSocketLanNetworkRule(
+	client *cato.Client,
+	rule *cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Rules_Rule,
+) error {
+	input := cato_models.SocketLanRemoveRuleInput{ID: rule.GetID()}
+	result, callErr := client.PolicySocketLanRemoveRule(ctx, nil, input, CatoAccountID)
+	action := fmt.Sprintf("deleting Socket LAN network rule %s (%s)", rule.GetName(), rule.GetID())
+	if result == nil {
+		return missingFirewallMutationResponse(action, callErr)
+	}
+	payload := result.GetPolicy().GetSocketLan().GetRemoveRule()
+	_, mutationErr := firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+	return mutationErr
+}
+
+func deleteSocketLanSection(
+	client *cato.Client,
+	section *cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_Sections_Section,
+) (bool, error) {
+	input := cato_models.PolicyRemoveSectionInput{ID: section.GetID()}
+	result, callErr := client.PolicySocketLanRemoveSection(ctx, nil, input, CatoAccountID)
+	action := fmt.Sprintf("deleting Socket LAN section %s (%s)", section.GetName(), section.GetID())
+	if result == nil {
+		return false, missingFirewallMutationResponse(action, callErr)
+	}
+	payload := result.GetPolicy().GetSocketLan().GetRemoveSection()
+	return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+}
+
+func deleteSocketLanSubPolicy(
+	client *cato.Client,
+	subPolicy *cato.PolicySocketLanPolicy_Policy_SocketLan_Policy_SubPolicies_Policy,
+) (bool, error) {
+	input := cato_models.SocketLanRemoveSubPolicyInput{
+		Ref: &cato_models.SocketLanPolicyRefInput{
+			By:    cato_models.ObjectRefByID,
+			Input: subPolicy.GetID(),
+		},
+	}
+	result, callErr := client.PolicySocketLanRemoveSubPolicy(ctx, nil, input, CatoAccountID)
+	action := fmt.Sprintf("deleting Socket LAN sub-policy %s (%s)", subPolicy.GetName(), subPolicy.GetID())
+	if result == nil {
+		return false, missingFirewallMutationResponse(action, callErr)
+	}
+	payload := result.GetPolicy().GetSocketLan().GetRemoveSubPolicy()
+	return firewallMutationResult(action, callErr, payload.GetStatus(), payload.GetErrors())
+}
+
+func publishSocketLanPolicy(client *cato.Client) error {
+	result, err := client.PolicySocketLanPublishPolicyRevision(
+		ctx, nil, &cato_models.PolicyPublishRevisionInput{}, CatoAccountID,
+	)
+	const action = "publishing Socket LAN policy revision"
+	if result == nil {
+		return missingFirewallMutationResponse(action, err)
+	}
+	payload := result.GetPolicy().GetSocketLan().GetPublishPolicyRevision()
+	_, publishErr := firewallMutationResult(action, err, payload.GetStatus(), payload.GetErrors())
+	return publishErr
 }
 
 func deletePrivateAccessRules(t *testing.T) error {
@@ -60,25 +291,55 @@ func deletePrivateAccessRules(t *testing.T) error {
 	if err != nil {
 		return err
 	}
-	rules := result.GetPolicy().GetPrivateAccess().GetPolicy().GetRules()
-	if len(rules) == 0 {
-		return nil
+	policy := result.GetPolicy().GetPrivateAccess().GetPolicy()
+	if revision := policy.GetRevision(); revision != nil {
+		if err = validateExistingPolicyRevision("Private Access", revision.GetID(), revision.GetChanges()); err != nil {
+			return err
+		}
 	}
+	rules := policy.GetRules()
 
+	changed := false
+	var cleanupErr error
 	for _, rule := range rules {
-		if !acctestRE.MatchString(rule.Rule.GetName()) {
+		if rule == nil || !acctestRE.MatchString(rule.Rule.GetName()) {
 			continue
 		}
 
 		input := cato_models.PrivateAccessRemoveRuleInput{ID: rule.Rule.ID}
-		_, err = client.PolicyPrivateAccessDeleteRule(context.Background(), CatoAccountID, input)
-		if err != nil {
-			return fmt.Errorf("deleting private access rule %s (%s): %v", rule.Rule.GetName(), rule.Rule.ID, err)
+		removeResult, callErr := client.PolicyPrivateAccessDeleteRule(ctx, CatoAccountID, input)
+		action := fmt.Sprintf("deleting private access rule %s (%s)", rule.Rule.GetName(), rule.Rule.ID)
+		if removeResult == nil {
+			cleanupErr = errors.Join(cleanupErr, missingFirewallMutationResponse(action, callErr))
+			continue
 		}
+		payload := removeResult.GetPolicy().GetPrivateAccess().GetRemoveRule()
+		succeeded, mutationErr := firewallMutationResult(
+			action,
+			callErr,
+			payload.GetStatus(),
+			payload.GetErrors(),
+		)
+		if mutationErr != nil {
+			cleanupErr = errors.Join(cleanupErr, mutationErr)
+		}
+		changed = changed || succeeded
 	}
-	if _, err = client.PolicyPrivateAccessPublishRevision(ctx, CatoAccountID); err != nil {
-		return fmt.Errorf("publishing private access revision: %v", err)
+	if !changed {
+		return cleanupErr
 	}
 
-	return nil
+	publishResult, callErr := client.PolicyPrivateAccessPublishRevision(ctx, CatoAccountID)
+	const action = "publishing private access revision"
+	if publishResult == nil {
+		return errors.Join(cleanupErr, missingFirewallMutationResponse(action, callErr))
+	}
+	payload := publishResult.GetPolicy().GetPrivateAccess().GetPublishPolicyRevision()
+	_, publishErr := firewallMutationResult(
+		action,
+		callErr,
+		payload.GetStatus(),
+		payload.GetErrors(),
+	)
+	return errors.Join(cleanupErr, publishErr)
 }

--- a/internal/acctests/acc/cleanup_tls_wan_network.go
+++ b/internal/acctests/acc/cleanup_tls_wan_network.go
@@ -1,0 +1,325 @@
+//go:build acctest
+
+package acc
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	cato "github.com/catonetworks/cato-go-sdk"
+	cato_models "github.com/catonetworks/cato-go-sdk/models"
+)
+
+type cleanupPolicyElement struct {
+	kind string
+	name string
+	id   string
+}
+
+type cleanupMutationResult struct {
+	status            *cato_models.PolicyMutationStatus
+	payloadErrors     any
+	payloadErrorCount int
+}
+
+type cleanupRemoveFunc func(string) (cleanupMutationResult, error)
+
+func deleteTLSInspectionElements(t *testing.T) error {
+	t.Helper()
+
+	client := GetClient(t)
+	result, err := client.Tlsinspectpolicy(ctx, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("reading TLS Inspection policy: %w", err)
+	}
+
+	policy := result.GetPolicy().GetTLSInspect().GetPolicy()
+	if err = validateTLSInspectionRevision(policy); err != nil {
+		return err
+	}
+	rules := make([]cleanupPolicyElement, 0)
+	for _, wrapper := range policy.GetRules() {
+		if wrapper == nil {
+			continue
+		}
+		rule := wrapper.GetRule()
+		if acctestRE.MatchString(rule.GetName()) {
+			rules = append(rules, cleanupPolicyElement{
+				kind: "TLS Inspection rule",
+				name: rule.GetName(),
+				id:   rule.GetID(),
+			})
+		}
+	}
+
+	sections := make([]cleanupPolicyElement, 0)
+	for _, wrapper := range policy.GetSections() {
+		if wrapper == nil {
+			continue
+		}
+		section := wrapper.GetSection()
+		if acctestRE.MatchString(section.GetName()) {
+			sections = append(sections, cleanupPolicyElement{
+				kind: "TLS Inspection section",
+				name: section.GetName(),
+				id:   section.GetID(),
+			})
+		}
+	}
+
+	rulesChanged, cleanupErr := removeCleanupPolicyElements(rules, func(id string) (cleanupMutationResult, error) {
+		response, removeErr := client.PolicyTLSInspectRemoveRule(
+			ctx,
+			cato_models.TLSInspectRemoveRuleInput{ID: id},
+			CatoAccountID,
+		)
+		if removeErr != nil {
+			return cleanupMutationResult{}, removeErr
+		}
+		if response == nil {
+			return cleanupMutationResult{}, errors.New("missing mutation response")
+		}
+
+		payload := response.GetPolicy().GetTLSInspect().GetRemoveRule()
+		payloadErrors := payload.GetErrors()
+		return cleanupMutationResult{
+			status:            payload.GetStatus(),
+			payloadErrors:     payloadErrors,
+			payloadErrorCount: len(payloadErrors),
+		}, nil
+	})
+
+	sectionsChanged, sectionErr := removeCleanupPolicyElements(
+		sections,
+		func(id string) (cleanupMutationResult, error) {
+			response, removeErr := client.PolicyTLSInspectRemoveSection(
+				ctx,
+				cato_models.PolicyRemoveSectionInput{ID: id},
+				CatoAccountID,
+			)
+			if removeErr != nil {
+				return cleanupMutationResult{}, removeErr
+			}
+			if response == nil {
+				return cleanupMutationResult{}, errors.New("missing mutation response")
+			}
+
+			payload := response.GetPolicy().GetTLSInspect().GetRemoveSection()
+			payloadErrors := payload.GetErrors()
+			return cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			}, nil
+		},
+	)
+	cleanupErr = errors.Join(cleanupErr, sectionErr)
+
+	if !rulesChanged && !sectionsChanged {
+		return cleanupErr
+	}
+
+	publishErr := publishTLSInspectionCleanup(client)
+	return errors.Join(cleanupErr, publishErr)
+}
+
+func deleteWanNetworkElements(t *testing.T) error {
+	t.Helper()
+
+	client := GetClient(t)
+	result, err := client.WanNetworkPolicy(ctx, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("reading WAN Network policy: %w", err)
+	}
+
+	policy := result.GetPolicy().GetWanNetwork().GetPolicy()
+	if err = validateWanNetworkRevision(policy); err != nil {
+		return err
+	}
+	rules := make([]cleanupPolicyElement, 0)
+	for _, wrapper := range policy.GetRules() {
+		if wrapper == nil {
+			continue
+		}
+		rule := wrapper.GetRule()
+		if acctestRE.MatchString(rule.GetName()) {
+			rules = append(rules, cleanupPolicyElement{
+				kind: "WAN Network rule",
+				name: rule.GetName(),
+				id:   rule.GetID(),
+			})
+		}
+	}
+
+	sections := make([]cleanupPolicyElement, 0)
+	for _, wrapper := range policy.GetSections() {
+		if wrapper == nil {
+			continue
+		}
+		section := wrapper.GetSection()
+		if acctestRE.MatchString(section.GetName()) {
+			sections = append(sections, cleanupPolicyElement{
+				kind: "WAN Network section",
+				name: section.GetName(),
+				id:   section.GetID(),
+			})
+		}
+	}
+
+	rulesChanged, cleanupErr := removeCleanupPolicyElements(rules, func(id string) (cleanupMutationResult, error) {
+		response, removeErr := client.PolicyWanNetworkRemoveRule(
+			ctx,
+			cato_models.WanNetworkRemoveRuleInput{ID: id},
+			CatoAccountID,
+		)
+		if removeErr != nil {
+			return cleanupMutationResult{}, removeErr
+		}
+		if response == nil {
+			return cleanupMutationResult{}, errors.New("missing mutation response")
+		}
+
+		payload := response.GetPolicy().GetWanNetwork().GetRemoveRule()
+		payloadErrors := payload.GetErrors()
+		return cleanupMutationResult{
+			status:            payload.GetStatus(),
+			payloadErrors:     payloadErrors,
+			payloadErrorCount: len(payloadErrors),
+		}, nil
+	})
+
+	sectionsChanged, sectionErr := removeCleanupPolicyElements(
+		sections,
+		func(id string) (cleanupMutationResult, error) {
+			response, removeErr := client.PolicyWanNetworkRemoveSection(
+				ctx,
+				cato_models.PolicyRemoveSectionInput{ID: id},
+				CatoAccountID,
+			)
+			if removeErr != nil {
+				return cleanupMutationResult{}, removeErr
+			}
+			if response == nil {
+				return cleanupMutationResult{}, errors.New("missing mutation response")
+			}
+
+			payload := response.GetPolicy().GetWanNetwork().GetRemoveSection()
+			payloadErrors := payload.GetErrors()
+			return cleanupMutationResult{
+				status:            payload.GetStatus(),
+				payloadErrors:     payloadErrors,
+				payloadErrorCount: len(payloadErrors),
+			}, nil
+		},
+	)
+	cleanupErr = errors.Join(cleanupErr, sectionErr)
+
+	if !rulesChanged && !sectionsChanged {
+		return cleanupErr
+	}
+
+	publishErr := publishWanNetworkCleanup(client)
+	return errors.Join(cleanupErr, publishErr)
+}
+
+func removeCleanupPolicyElements(
+	elements []cleanupPolicyElement,
+	remove cleanupRemoveFunc,
+) (bool, error) {
+	changed := false
+	var cleanupErr error
+
+	for _, element := range elements {
+		action := fmt.Sprintf("deleting %s %s (%s)", element.kind, element.name, element.id)
+		result, err := remove(element.id)
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("%s: %w", action, err))
+			continue
+		}
+		if err = validateCleanupMutation(action, result); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+		changed = true
+	}
+
+	return changed, cleanupErr
+}
+
+func publishTLSInspectionCleanup(client *cato.Client) error {
+	response, err := client.PolicyTLSInspectPublishPolicyRevision(ctx, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("publishing TLS Inspection policy revision: %w", err)
+	}
+	if response == nil {
+		return errors.New("publishing TLS Inspection policy revision: missing mutation response")
+	}
+
+	payload := response.GetPolicy().GetTLSInspect().GetPublishPolicyRevision()
+	payloadErrors := payload.GetErrors()
+	return validateCleanupMutation("publishing TLS Inspection policy revision", cleanupMutationResult{
+		status:            payload.GetStatus(),
+		payloadErrors:     payloadErrors,
+		payloadErrorCount: len(payloadErrors),
+	})
+}
+
+func publishWanNetworkCleanup(client *cato.Client) error {
+	response, err := client.PolicyWanNetworkPublishPolicyRevision(ctx, CatoAccountID)
+	if err != nil {
+		return fmt.Errorf("publishing WAN Network policy revision: %w", err)
+	}
+	if response == nil {
+		return errors.New("publishing WAN Network policy revision: missing mutation response")
+	}
+
+	payload := response.GetPolicy().GetWanNetwork().GetPublishPolicyRevision()
+	payloadErrors := payload.GetErrors()
+	return validateCleanupMutation("publishing WAN Network policy revision", cleanupMutationResult{
+		status:            payload.GetStatus(),
+		payloadErrors:     payloadErrors,
+		payloadErrorCount: len(payloadErrors),
+	})
+}
+
+func validateCleanupMutation(action string, result cleanupMutationResult) error {
+	if result.status != nil &&
+		*result.status == cato_models.PolicyMutationStatusSuccess &&
+		result.payloadErrorCount == 0 {
+		return nil
+	}
+
+	status := "<nil>"
+	if result.status != nil {
+		status = string(*result.status)
+	}
+
+	payloadErrors, err := json.Marshal(result.payloadErrors)
+	if err != nil {
+		return fmt.Errorf(
+			"%s: mutation status %s, payload errors could not be encoded: %v",
+			action,
+			status,
+			err,
+		)
+	}
+	return fmt.Errorf("%s: mutation status %s, payload errors %s", action, status, payloadErrors)
+}
+
+func validateTLSInspectionRevision(policy *cato.Tlsinspectpolicy_Policy_TLSInspect_Policy) error {
+	revision := policy.GetRevision()
+	if revision == nil {
+		return nil
+	}
+	return validateExistingPolicyRevision("TLS Inspection", revision.GetID(), revision.GetChanges())
+}
+
+func validateWanNetworkRevision(policy *cato.WanNetworkPolicy_Policy_WanNetwork_Policy) error {
+	revision := policy.GetRevision()
+	if revision == nil {
+		return nil
+	}
+	return validateExistingPolicyRevision("WAN Network", revision.GetID(), revision.GetChanges())
+}

--- a/internal/acctests/acc/common.go
+++ b/internal/acctests/acc/common.go
@@ -4,16 +4,12 @@ package acc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"math/rand"
-	"net/http"
 	"os"
 	"regexp"
 	"runtime"
 	"slices"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -47,6 +43,7 @@ const (
 
 	// entity lookup types
 	resUsers                   = "vpnUser"
+	resAccount                 = "account"
 	resDhcpRelayGroup          = "dhcpRelayGroup"
 	resLocation                = "location"
 	resHost                    = "host"
@@ -61,37 +58,9 @@ const (
 var (
 	CatoAccountID = os.Getenv(envCatoAccountID)
 	CatoToken     = os.Getenv(envCatoToken)
-	httpClient    = &http.Client{}
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-
-type entityResp struct {
-	Data   entityData  `json:"data"`
-	Errors []respError `json:"errors"`
-}
-
-type respError struct {
-	Msg  string   `json:"message"`
-	Path []string `json:"path"`
-}
-
-type entityData struct {
-	EntityLookup entityLookup `json:"entityLookup"`
-}
-
-type entityLookup struct {
-	Items []entityItem `json:"items"`
-}
-
-type entityItem struct {
-	Entity entityDetail `json:"entity"`
-}
-
-type entityDetail struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
 
 type Ref struct {
 	Name string `json:"name"`
@@ -152,7 +121,10 @@ func PrintAttributes(resource string) func(st *terraform.State) error {
 	}
 }
 
-var funcPrefixRE = regexp.MustCompile(`^.*\.`)
+var (
+	acctestRE    = regexp.MustCompile(`^acctest_`)
+	funcPrefixRE = regexp.MustCompile(`^.*\.`)
+)
 
 func SkipByEnv(t *testing.T) {
 	pc, _, _, ok := runtime.Caller(1)
@@ -354,6 +326,9 @@ func GetGlobalIPRanges(t *testing.T) []Ref {
 
 	items := result.GetObject().GetGlobalIPRangeList().GetItems()
 	for _, item := range items {
+		if item == nil || !acctestRE.MatchString(item.GetName()) {
+			continue
+		}
 		testIPRanges = append(testIPRanges, Ref{ID: item.GetID(), Name: item.GetName()})
 		rangesFound = append(rangesFound, item.GetName())
 	}
@@ -386,29 +361,8 @@ func DeleteGlobalIPRanges(t *testing.T) {
 	if accmock.ACCMockActive {
 		return
 	}
-	client := GetClient(t)
-
-	// try to fetch IP ranges
-	result, err := client.ObjectGlobalIPRangeList(ctx, CatoAccountID, nil)
-	if err != nil {
-		t.Fatalf("failed to load global IP ranges: %v", err)
-		return
-	}
-	ranges := result.GetObject().GetGlobalIPRangeList().GetItems()
-	// delete IP ranges
-	if len(ranges) == 0 {
-		return
-	}
-
-	// prepare input for deletion
-	input := make([]*cato_models.GlobalIPRangeRefInput, 0, len(ranges))
-	for _, r := range ranges {
-		input = append(input, &cato_models.GlobalIPRangeRefInput{By: cato_models.ObjectRefByID, Input: r.ID})
-	}
-	_, err = client.ObjectDeleteGlobalIPRangeBulk(ctx, CatoAccountID, input)
-	if err != nil {
-		t.Fatalf("failed to delete global IP ranges: %v", err)
-		return
+	if err := deleteAcctestGlobalIPRanges(t); err != nil {
+		t.Fatalf("failed to delete acctest global IP ranges: %v", err)
 	}
 }
 
@@ -418,48 +372,56 @@ func ProviderCfg() string {
 
 // getEntities is a generic function to call entityLookup API and return a []Ref (name and ID of the entities)
 func getEntities(t *testing.T, entityType string) (refs []Ref) {
-	var res entityResp
-	query := `{"query": "query entityLookup ($accountID:ID! $type:EntityType!) ` +
-		`{entityLookup (accountID:$accountID type:$type) {items {entity {id name}}}}",
-			"variables": {"accountID": "` + CatoAccountID + `","type": "` + entityType + `"},
-			"operationName": "entityLookup"}`
+	const (
+		pageLimit = int64(100)
+		maxPages  = 1000
+	)
 
-	// Create request
-	req, err := http.NewRequest(http.MethodPost, os.Getenv(envCatoEndpoint), strings.NewReader(query)) //nolint:gosec
-	if err != nil {
-		panic(err)
+	entityTypeValue := cato_models.EntityType(entityType)
+	if !entityTypeValue.IsValid() {
+		t.Fatalf("invalid entity type %q", entityType)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Api-Key", CatoToken)
-	resp, err := httpClient.Do(req) //nolint:gosec
-	if err != nil {
-		t.Fatalf("ERROR fetching %q: %v", entityType, err)
-	}
-	defer func() {
-		if errClose := resp.Body.Close(); errClose != nil {
-			t.Logf("ERROR closing response body: %v", errClose)
+
+	client := GetClient(t)
+	from := int64(0)
+	for page := 0; page < maxPages; page++ {
+		result, err := client.EntityLookup(
+			ctx, CatoAccountID, entityTypeValue, ptr(pageLimit), &from,
+			nil, nil, nil, nil, nil, nil,
+		)
+		if err != nil {
+			t.Fatalf("ERROR fetching %q: %v", entityType, err)
 		}
-	}()
+		if result == nil || result.GetEntityLookup() == nil {
+			t.Fatalf("ERROR fetching %q: missing response payload", entityType)
+		}
 
-	// Read response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("ERROR reading %q: %v", entityType, err)
-	}
-	if err = json.Unmarshal(body, &res); err != nil {
-		t.Fatalf("ERROR unmarshalling response: %v", err)
-	}
-	if len(res.Errors) > 0 {
-		t.Fatalf("ERROR: cannot fetch %q: %v", entityType, res.Errors)
-	}
-	if len(res.Data.EntityLookup.Items) == 0 {
-		t.Fatalf("ERROR: failed to fetch %q: res.Data.EntityLookup.Items is empty", entityType)
-	}
-	for _, u := range res.Data.EntityLookup.Items {
-		refs = append(refs, Ref{ID: u.Entity.ID, Name: u.Entity.Name})
+		lookup := result.GetEntityLookup()
+		items := lookup.GetItems()
+		for _, item := range items {
+			if item == nil || item.GetEntity() == nil || item.GetEntity().GetName() == nil {
+				continue
+			}
+			refs = append(refs, Ref{ID: item.GetEntity().GetID(), Name: *item.GetEntity().GetName()})
+		}
+
+		from += int64(len(items))
+		if total := lookup.GetTotal(); total != nil {
+			if from >= *total {
+				return refs
+			}
+			if len(items) == 0 {
+				t.Fatalf("ERROR fetching %q: empty page before total %d", entityType, *total)
+			}
+			continue
+		}
+		if len(items) < int(pageLimit) {
+			return refs
+		}
 	}
 
-	return refs
+	t.Fatalf("ERROR fetching %q: exceeded %d pages", entityType, maxPages)
+	return nil
 }
 
 func getFromVars(t *testing.T, varName string) []Ref {

--- a/internal/acctests/acc/policy_revision_cleanup.go
+++ b/internal/acctests/acc/policy_revision_cleanup.go
@@ -76,10 +76,19 @@ func discardInternetFirewallPolicyRevision(client *cato.Client, revisionID strin
 	if err != nil {
 		return fmt.Errorf("discard internet firewall revision %s: %w", revisionID, err)
 	}
-	if errs := resp.GetPolicy().GetInternetFirewall().GetDiscardPolicyRevision().GetErrors(); len(errs) > 0 {
-		return fmt.Errorf("discard internet firewall revision %s: %v", revisionID, errs)
+	if resp == nil {
+		return fmt.Errorf("discard internet firewall revision %s: missing response", revisionID)
 	}
-	return nil
+	payload := resp.GetPolicy().GetInternetFirewall().GetDiscardPolicyRevision()
+	payloadErrors := payload.GetErrors()
+	return validateCleanupMutation(
+		fmt.Sprintf("discard internet firewall revision %s", revisionID),
+		cleanupMutationResult{
+			status:            payload.GetStatus(),
+			payloadErrors:     payloadErrors,
+			payloadErrorCount: len(payloadErrors),
+		},
+	)
 }
 
 func discardWanFirewallPolicyRevision(client *cato.Client, revisionID string) error {
@@ -90,10 +99,19 @@ func discardWanFirewallPolicyRevision(client *cato.Client, revisionID string) er
 	if err != nil {
 		return fmt.Errorf("discard WAN firewall revision %s: %w", revisionID, err)
 	}
-	if errs := resp.GetPolicy().GetWanFirewall().GetDiscardPolicyRevision().GetErrors(); len(errs) > 0 {
-		return fmt.Errorf("discard WAN firewall revision %s: %v", revisionID, errs)
+	if resp == nil {
+		return fmt.Errorf("discard WAN firewall revision %s: missing response", revisionID)
 	}
-	return nil
+	payload := resp.GetPolicy().GetWanFirewall().GetDiscardPolicyRevision()
+	payloadErrors := payload.GetErrors()
+	return validateCleanupMutation(
+		fmt.Sprintf("discard WAN firewall revision %s", revisionID),
+		cleanupMutationResult{
+			status:            payload.GetStatus(),
+			payloadErrors:     payloadErrors,
+			payloadErrorCount: len(payloadErrors),
+		},
+	)
 }
 
 func discardWanNetworkPolicyRevision(client *cato.Client, revisionID string) error {
@@ -101,8 +119,17 @@ func discardWanNetworkPolicyRevision(client *cato.Client, revisionID string) err
 	if err != nil {
 		return fmt.Errorf("discard WAN network revision %s: %w", revisionID, err)
 	}
-	if errs := resp.GetPolicy().GetWanNetwork().GetDiscardPolicyRevision().GetErrors(); len(errs) > 0 {
-		return fmt.Errorf("discard WAN network revision %s: %v", revisionID, errs)
+	if resp == nil {
+		return fmt.Errorf("discard WAN network revision %s: missing response", revisionID)
 	}
-	return nil
+	payload := resp.GetPolicy().GetWanNetwork().GetDiscardPolicyRevision()
+	payloadErrors := payload.GetErrors()
+	return validateCleanupMutation(
+		fmt.Sprintf("discard WAN network revision %s", revisionID),
+		cleanupMutationResult{
+			status:            payload.GetStatus(),
+			payloadErrors:     payloadErrors,
+			payloadErrorCount: len(payloadErrors),
+		},
+	)
 }


### PR DESCRIPTION
Remove policy dependencies before sites and restrict destructive cleanup to acctest-owned entities. Refuse drafts containing pending changes.