### PR TITLE
v0.0.98

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=catonetworks
 PKG_NAME=cato
 BINARY=terraform-provider-${PKG_NAME}
-VERSION=0.0.97
+VERSION=0.0.98
 
 # Mac Intel Chip
 # OS_ARCH=darwin_amd64

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.0.98 (2026-09-08)
+
+### Fixed
+- Fixed `cato_global_ip_ranges` validation to accept individual IPv4 and IPv6 addresses without CIDR prefixes.
+- Fixed `cato_static_host` state refresh to use site-scoped configuration and require site context during import, so Console Management Application drift is detected reliably.
+
+### Changed
+- Updated the Cato Go SDK dependency to v0.4.1.
+- Updated release documentation for customer-facing release notes and announcements.
+
+### Tests
+- Added unit and acceptance coverage for global IP range validation, static host drift detection, and static host import.
+
 ## 0.0.97 (2026-09-01)
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	version string = "0.0.97"
+	version string = "0.0.98"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Prepare provider release `v0.0.98`.

## Changelog

## 0.0.98 (2026-09-08)

### Fixed
- Fixed `cato_global_ip_ranges` validation to accept individual IPv4 and IPv6 addresses without CIDR prefixes.
- Fixed `cato_static_host` state refresh to use site-scoped configuration and require site context during import, so Console Management Application drift is detected reliably.

### Changed
- Updated the Cato Go SDK dependency to v0.4.1.
- Updated release documentation for customer-facing release notes and announcements.

### Tests
- Added unit and acceptance coverage for global IP range validation, static host drift detection, and static host import.

## Test plan
- [x] `make sort-imports`
- [x] `make docs`
- [x] `make test`
- [x] `make lint`
- [x] `make vul`